### PR TITLE
Problem iteration

### DIFF
--- a/doc/sphinx/docs/cpp/miscellanea/generic.rst
+++ b/doc/sphinx/docs/cpp/miscellanea/generic.rst
@@ -19,10 +19,6 @@ A number of utilities to compute quantities that are of general relevance.
 
 --------------------------------------------------------------------------
 
-.. doxygenfunction:: pagmo::safe_cast
-
---------------------------------------------------------------------------
-
 .. doxygenfunction:: pagmo::binomial_coefficient
 
 --------------------------------------------------------------------------

--- a/include/pagmo/algorithms/moead.hpp
+++ b/include/pagmo/algorithms/moead.hpp
@@ -43,7 +43,7 @@ see https://www.gnu.org/licenses/. */
 #include "../problem.hpp"
 #include "../problems/decompose.hpp"
 #include "../rng.hpp"
-#include "../utils/generic.hpp"         // safe_cast, kNN
+#include "../utils/generic.hpp"         // kNN
 #include "../utils/multi_objective.hpp" // ideal
 
 namespace pagmo

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -31,6 +31,7 @@ see https://www.gnu.org/licenses/. */
 
 #include <algorithm>
 #include <atomic>
+#include <boost/numeric/conversion/cast.hpp>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -1118,7 +1119,7 @@ public:
             }
             // We resize rather than push back here, so that an std::length_error is called quickly rather
             // than an std::bad_alloc after waiting the growth
-            m_hs_dim.resize(nf);
+            m_hs_dim.resize(boost::numeric_cast<decltype(m_hs_dim.size())>(nf));
             for (vector_double::size_type i = 0u; i < nf; ++i) {
                 m_hs_dim[i] = (nx * (nx - 1u) / 2u + nx); // lower triangular
             }

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -178,33 +178,6 @@ inline vector_double random_decision_vector(const vector_double &lb, const vecto
     return random_decision_vector({lb, ub}, r_engine);
 }
 
-/// Safely cast between unsigned types
-/**
- * Performs a cast between unsigned types throwing if the input cannot be represented in the new type
- *
- * Example:
- * @code{.unparsed}
- * unsigned short s = std::numeric_limits<unsigned short>::max();
- * unsigned long l = std::numeric_limits<unsigned long>::max();
- * auto res1 = safe_cast<unsigned long>(s); // Will always work
- * auto res2 = safe_cast<unsigned short>(l); // Will throw an std::overflow_error if precision is lost
- * @endcode
- *
- * @param x an unsigned value \p x to be casted to \p T
- * @return the input \p x safey casted to \p T
- * @throws std::overflow_error if \p x cannot be represented by the new type
- */
-template <typename T, typename U>
-inline T safe_cast(const U &x)
-{
-    static_assert(std::is_unsigned<T>::value && std::is_unsigned<U>::value,
-                  "Safe cast can only be used on unsigned types");
-    if (x > std::numeric_limits<T>::max()) {
-        pagmo_throw(std::overflow_error, "Converting between unsigned types caused a loss");
-    }
-    return static_cast<T>(x);
-}
-
 /// Binomial coefficient
 /**
  * An implementation of the binomial coefficient using gamma functions

--- a/include/pagmo/utils/multi_objective.hpp
+++ b/include/pagmo/utils/multi_objective.hpp
@@ -37,6 +37,7 @@ see https://www.gnu.org/licenses/. */
  */
 
 #include <algorithm>
+#include <boost/numeric/conversion/cast.hpp>
 #include <limits>
 #include <numeric>
 #include <stdexcept>
@@ -589,7 +590,7 @@ inline vector_double nadir(const std::vector<vector_double> &points)
  * @returns an <tt>std:vector</tt> containing the weight vectors
  *
  * @throws if the population size is not compatible with the selected weight generation method
-**/
+ */
 inline std::vector<vector_double> decomposition_weights(vector_double::size_type n_f, vector_double::size_type n_w,
                                                         const std::string &weight_generation,
                                                         detail::random_engine_type &r_engine)
@@ -652,7 +653,7 @@ inline std::vector<vector_double> decomposition_weights(vector_double::size_type
             retval[i][i] = 1.;
         }
         // Then we add points on the simplex randomly genrated using Halton low discrepancy sequence
-        halton ld_seq{safe_cast<unsigned int>(n_f - 1u), safe_cast<unsigned int>(n_f)};
+        halton ld_seq{boost::numeric_cast<unsigned int>(n_f - 1u), boost::numeric_cast<unsigned int>(n_f)};
         for (decltype(n_w) i = n_f; i < n_w; ++i) {
             retval.push_back(sample_from_simplex(ld_seq()));
         }

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -1190,6 +1190,23 @@ class problem_test_case(_ut.TestCase):
 
         self.assertRaises(TypeError, lambda: problem(p()))
 
+        class p(object):
+            counter = 0
+
+            def get_bounds(self):
+                return ([0], [1])
+
+            def fitness(self, a):
+                return [42]
+
+            def gradient_sparsity(self):
+                if p.counter == 0:
+                    p.counter = p.counter + 1
+                    return []
+                return [(0, 0)]
+
+        self.assertRaises(ValueError, lambda: problem(p()).gradient_sparsity())
+
     def run_has_hessians_tests(self):
         from .core import problem
 
@@ -1341,6 +1358,22 @@ class problem_test_case(_ut.TestCase):
         self.assert_(all(array([4., 5., 6.]) ==
                          problem(p()).hessians([1, 2])[1]))
         self.assertRaises(ValueError, lambda: problem(p()).hessians([1]))
+
+        class p(object):
+
+            def get_bounds(self):
+                return ([0]*6, [1]*6)
+
+            def fitness(self, a):
+                return [42, -42]
+
+            def get_nobj(self):
+                return 2
+
+            def hessians(self, a):
+                return []
+
+        self.assertRaises(ValueError, lambda: problem(p()).hessians([1]*6))
 
     def run_has_hessians_sparsity_tests(self):
         from .core import problem
@@ -1677,6 +1710,26 @@ class problem_test_case(_ut.TestCase):
                       == array([[0, 0], [1, 1]])).all())
         self.assert_((problem(p()).hessians_sparsity()[1]
                       == array([[0, 0], [1, 0]])).all())
+
+        class p(object):
+            counter = 0
+
+            def get_bounds(self):
+                return ([0]*6, [1]*6)
+
+            def fitness(self, a):
+                return [42, 42]
+
+            def get_nobj(self):
+                return 2
+
+            def hessians_sparsity(self):
+                if p.counter == 0:
+                    p.counter = p.counter + 1
+                    return [[(1, 0)], [(1, 0)]]
+                return [[(1, 0)], [(1, 0), (2, 0)]]
+
+        self.assertRaises(ValueError, lambda: problem(p()).hessians_sparsity())
 
     def run_seed_tests(self):
         from .core import problem

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -1207,6 +1207,19 @@ class problem_test_case(_ut.TestCase):
 
         self.assertRaises(ValueError, lambda: problem(p()).gradient_sparsity())
 
+        class p(object):
+
+            def get_bounds(self):
+                return ([0]*6, [1]*6)
+
+            def fitness(self, a):
+                return [42]
+
+            def gradient_sparsity(self):
+                return [(0, 0),(0,2),(0,1)]
+
+        self.assertRaises(ValueError, lambda: problem(p()))
+
     def run_has_hessians_tests(self):
         from .core import problem
 
@@ -1730,6 +1743,22 @@ class problem_test_case(_ut.TestCase):
                 return [[(1, 0)], [(1, 0), (2, 0)]]
 
         self.assertRaises(ValueError, lambda: problem(p()).hessians_sparsity())
+
+        class p(object):
+
+            def get_bounds(self):
+                return ([0]*6, [1]*6)
+
+            def fitness(self, a):
+                return [42, 42]
+
+            def get_nobj(self):
+                return 2
+
+            def hessians_sparsity(self):
+                return [[(1, 0)], [(1, 0), (2, 0), (1,1)]]
+
+        self.assertRaises(ValueError, lambda: problem(p()))
 
     def run_seed_tests(self):
         from .core import problem

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -754,7 +754,7 @@ std::string problem_gradient_sparsity_docstring()
 
 Gradient sparsity pattern.
 
-This method will return the gradient sparsity pattern of the problem. The gradient sparsity pattern is a
+This method will return the gradient sparsity pattern of the problem. The gradient sparsity pattern is a lexicographically sorted
 collection of the indices :math:`(i,j)` of the non-zero elements of :math:`g_{ij} = \frac{\partial f_i}{\partial x_j}`.
 
 If :func:`~pygmo.core.problem.has_gradient_sparsity()` returns ``True``, then the ``gradient_sparsity()`` method of the
@@ -778,7 +778,7 @@ Raises:
         shape, dimensions, etc.),
       * at least one element of the returned iterable Python object does not consist of a collection of exactly
         2 elements,
-      * if the sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices,
+      * if the sparsity pattern returned by the UDP is invalid (specifically, if it is not strictly sorted lexicographically,
         or if the indices in the pattern are incompatible with the properties of the problem, or if the size of the
         returned pattern is different from the size recorded upon construction)
     OverflowError: if the NumPy array returned by the UDP contains integer values which are negative or outside an
@@ -894,7 +894,7 @@ std::string problem_hessians_sparsity_docstring()
 Hessians sparsity pattern.
 
 This method will return the hessians sparsity pattern of the problem. Each component :math:`l` of the hessians
-sparsity pattern is a collection of the indices :math:`(i,j)` of the non-zero elements of
+sparsity pattern is a lexicographically sorted collection of the indices :math:`(i,j)` of the non-zero elements of
 :math:`h^l_{ij} = \frac{\partial f^l}{\partial x_i\partial x_j}`. Since the Hessian matrix is symmetric, only
 lower triangular elements are allowed.
 
@@ -920,7 +920,7 @@ Raises:
         shape, dimensions, etc.),
       * at least one element of a returned iterable Python object does not consist of a collection of exactly
         2 elements,
-      * if a sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices,
+      * if a sparsity pattern returned by the UDP is invalid (specifically, if it is not strictly sorted lexicographically,
         if the indices in the pattern are incompatible with the properties of the problem or if the size of the pattern
         differs from the size recorded upon construction)
     OverflowError: if the NumPy arrays returned by the UDP contain integer values which are negative or outside an

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -778,8 +778,9 @@ Raises:
         shape, dimensions, etc.),
       * at least one element of the returned iterable Python object does not consist of a collection of exactly
         2 elements,
-      * if the sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices
-        or if the indices in the pattern are incompatible with the properties of the problem)
+      * if the sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices,
+        or if the indices in the pattern are incompatible with the properties of the problem, or if the size of the
+        returned pattern is different from the size recorded upon construction)
     OverflowError: if the NumPy array returned by the UDP contains integer values which are negative or outside an
       implementation-defined range
     unspecified: any exception thrown by:
@@ -847,8 +848,9 @@ Returns:
     ``list`` of 1D NumPy float array: the hessians of *dv*
 
 Raises:
-    ValueError: if either the length of *dv* differs from the value returned by :func:`~pygmo.core.problem.get_nx()`, or
-      the length of returned hessians does not match the corresponding hessians sparsity pattern dimensions
+    ValueError: if the length of *dv* differs from the value returned by :func:`~pygmo.core.problem.get_nx()`, or
+      the length of returned hessians does not match the corresponding hessians sparsity pattern dimensions, or
+      the size of the return value is not equal to the fitness dimension
     NotImplementedError: if the UDP does not provide a ``hessians()`` method
     unspecified: any exception thrown by the ``hessians()`` method of the UDP, or by failures at the intersection
       between C++ and Python (e.g., type conversion errors, mismatched function signatures, etc.)
@@ -918,8 +920,9 @@ Raises:
         shape, dimensions, etc.),
       * at least one element of a returned iterable Python object does not consist of a collection of exactly
         2 elements,
-      * if a sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices
-        or if the indices in the pattern are incompatible with the properties of the problem)
+      * if a sparsity pattern returned by the UDP is invalid (specifically, if it contains duplicate pairs of indices,
+        if the indices in the pattern are incompatible with the properties of the problem or if the size of the pattern
+        differs from the size recorded upon construction)
     OverflowError: if the NumPy arrays returned by the UDP contain integer values which are negative or outside an
       implementation-defined range
     unspecified: any exception thrown by:

--- a/tests/generic.cpp
+++ b/tests/generic.cpp
@@ -130,16 +130,6 @@ BOOST_AUTO_TEST_CASE(force_bounds_test)
     }
 }
 
-BOOST_AUTO_TEST_CASE(safe_cast_test)
-{
-    unsigned short s = std::numeric_limits<unsigned short>::max();
-    unsigned long l = std::numeric_limits<unsigned long>::max();
-    BOOST_CHECK_NO_THROW(safe_cast<unsigned long>(s));
-    if (l > s) {
-        BOOST_CHECK_THROW(safe_cast<unsigned short>(l), std::overflow_error);
-    }
-}
-
 BOOST_AUTO_TEST_CASE(binomial_coefficient_test)
 {
     BOOST_CHECK_EQUAL(binomial_coefficient(0u, 0u), 1u);

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -1108,3 +1108,129 @@ BOOST_AUTO_TEST_CASE(thread_safety_test)
     BOOST_CHECK(problem{ts2{}}.get_thread_safety() == thread_safety::none);
     BOOST_CHECK(problem{ts3{}}.get_thread_safety() == thread_safety::basic);
 }
+
+struct gs1 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    sparsity_pattern gradient_sparsity() const
+    {
+        if (!n_grad_invs) {
+            ++n_grad_invs;
+            return {};
+        }
+        return {{0, 0}};
+    }
+    static int n_grad_invs;
+};
+
+int gs1::n_grad_invs = 0;
+
+struct gs2 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    sparsity_pattern gradient_sparsity() const
+    {
+        return {{0, 0}};
+    }
+};
+
+BOOST_AUTO_TEST_CASE(custom_gs)
+{
+    // Test a gradient sparsity that changes after the first invocation of gradient_sparsity().
+    problem p{gs1{}};
+    BOOST_CHECK_THROW(p.gradient_sparsity(), std::invalid_argument);
+    p = problem{gs2{}};
+    BOOST_CHECK_NO_THROW(p.gradient_sparsity());
+}
+
+struct hs1 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2;
+    }
+    std::vector<sparsity_pattern> hessians_sparsity() const
+    {
+        if (!n_hess_invs) {
+            ++n_hess_invs;
+            return {{{1, 0}}, {{1, 0}}};
+        }
+        return {{{1, 0}}, {{1, 0}, {2, 0}}};
+    }
+    static int n_hess_invs;
+};
+
+int hs1::n_hess_invs = 0;
+
+struct hs2 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2;
+    }
+    std::vector<sparsity_pattern> hessians_sparsity() const
+    {
+        return {{{1, 0}}, {{1, 0}, {2, 0}}};
+    }
+};
+
+BOOST_AUTO_TEST_CASE(custom_hs)
+{
+    // Test a hessians sparsity that changes after the first invocation of hessians_sparsity().
+    problem p{hs1{}};
+    BOOST_CHECK_THROW(p.hessians_sparsity(), std::invalid_argument);
+    p = problem{hs2{}};
+    BOOST_CHECK_NO_THROW(p.hessians_sparsity());
+}
+
+struct hess1 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2;
+    }
+    std::vector<vector_double> hessians(const vector_double &) const
+    {
+        return {{}};
+    }
+};
+
+BOOST_AUTO_TEST_CASE(broken_hessian)
+{
+    // Test a hessians method that returns a number of vectors different from get_nf().
+    problem p{hess1{}};
+    BOOST_CHECK_THROW(p.hessians({1, 1, 1, 1, 1, 1}), std::invalid_argument);
+}

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -1146,6 +1146,21 @@ struct gs2 {
     }
 };
 
+struct gs3 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    sparsity_pattern gradient_sparsity() const
+    {
+        return {{0, 0}, {0, 2}, {0, 1}};
+    }
+};
+
 BOOST_AUTO_TEST_CASE(custom_gs)
 {
     // Test a gradient sparsity that changes after the first invocation of gradient_sparsity().
@@ -1153,6 +1168,8 @@ BOOST_AUTO_TEST_CASE(custom_gs)
     BOOST_CHECK_THROW(p.gradient_sparsity(), std::invalid_argument);
     p = problem{gs2{}};
     BOOST_CHECK_NO_THROW(p.gradient_sparsity());
+    // Gradient sparsity not sorted.
+    BOOST_CHECK_THROW(p = problem{gs3{}}, std::invalid_argument);
 }
 
 struct hs1 {
@@ -1200,6 +1217,25 @@ struct hs2 {
     }
 };
 
+struct hs3 {
+    vector_double fitness(const vector_double &) const
+    {
+        return {0, 0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 1}};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2;
+    }
+    std::vector<sparsity_pattern> hessians_sparsity() const
+    {
+        return {{{1, 0}, {2, 1}, {1, 1}}, {{1, 0}, {2, 0}}};
+    }
+};
+
 BOOST_AUTO_TEST_CASE(custom_hs)
 {
     // Test a hessians sparsity that changes after the first invocation of hessians_sparsity().
@@ -1207,6 +1243,7 @@ BOOST_AUTO_TEST_CASE(custom_hs)
     BOOST_CHECK_THROW(p.hessians_sparsity(), std::invalid_argument);
     p = problem{hs2{}};
     BOOST_CHECK_NO_THROW(p.hessians_sparsity());
+    BOOST_CHECK_THROW(p = problem{hs3{}}, std::invalid_argument);
 }
 
 struct hess1 {


### PR DESCRIPTION
Some work on the problem class from initial experience on nlopt integration. I'll try to describe the 3 commits here.

The first bit is easy: remove ``safe_cast`` in favour of ``boost::numeric_cast``, since we now depend on Boost anyway. Code removed, life is good.

The second bit implements some additional checking on the return values of ``gradient_sparsity()`` and ``hessians_sparsity()``. Specifically, we now check also that the returned value's dimension(s) is consistent with the dimension(s) recorded as problem members during problem construction. This was prompted by the realisation that, with an UDP which is badly behaved enough, we can trigger out-of-bounds memory accesses when mapping a sparse gradient to a dense one. This is because, for instance ``gradient()`` checks that the returned value is consistent with ``m_gs_dim`` but ``gradient_sparsity()`` previously didn't (so potentially the problem previously could return a gradient sparsity pattern inconsistent with the size of the sparse gradient vector). Same for hessians.

The third bit enforces that all sparsity patterns need to be sorted lexicographically. This is what we were always doing anyway (no tests had to be altered), and in my opinion it makes it easier to reason about and handle the sparsity information. It is also consistent with many standard formats for storing sparse data.

