### PR TITLE
Fix archi init in python not to use the same island for initialization of multiple islands.

### DIFF
--- a/pygmo/__init__.py
+++ b/pygmo/__init__.py
@@ -434,7 +434,10 @@ def _archi_init(self, n=0, **kwargs):
             "the 'n' parameter must be non-negative, but it is {} instead".format(n))
 
     # Call the original init.
-    __original_archi_init(self, n, island(**kwargs))
+    __original_archi_init(self)
+    # Push back islands.
+    for _ in range(n):
+        self.push_back(**kwargs)
 
 setattr(archipelago, "__init__", _archi_init)
 

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -1210,13 +1210,13 @@ class problem_test_case(_ut.TestCase):
         class p(object):
 
             def get_bounds(self):
-                return ([0]*6, [1]*6)
+                return ([0] * 6, [1] * 6)
 
             def fitness(self, a):
                 return [42]
 
             def gradient_sparsity(self):
-                return [(0, 0),(0,2),(0,1)]
+                return [(0, 0), (0, 2), (0, 1)]
 
         self.assertRaises(ValueError, lambda: problem(p()))
 
@@ -1375,7 +1375,7 @@ class problem_test_case(_ut.TestCase):
         class p(object):
 
             def get_bounds(self):
-                return ([0]*6, [1]*6)
+                return ([0] * 6, [1] * 6)
 
             def fitness(self, a):
                 return [42, -42]
@@ -1386,7 +1386,7 @@ class problem_test_case(_ut.TestCase):
             def hessians(self, a):
                 return []
 
-        self.assertRaises(ValueError, lambda: problem(p()).hessians([1]*6))
+        self.assertRaises(ValueError, lambda: problem(p()).hessians([1] * 6))
 
     def run_has_hessians_sparsity_tests(self):
         from .core import problem
@@ -1728,7 +1728,7 @@ class problem_test_case(_ut.TestCase):
             counter = 0
 
             def get_bounds(self):
-                return ([0]*6, [1]*6)
+                return ([0] * 6, [1] * 6)
 
             def fitness(self, a):
                 return [42, 42]
@@ -1747,7 +1747,7 @@ class problem_test_case(_ut.TestCase):
         class p(object):
 
             def get_bounds(self):
-                return ([0]*6, [1]*6)
+                return ([0] * 6, [1] * 6)
 
             def fitness(self, a):
                 return [42, 42]
@@ -1756,7 +1756,7 @@ class problem_test_case(_ut.TestCase):
                 return 2
 
             def hessians_sparsity(self):
-                return [[(1, 0)], [(1, 0), (2, 0), (1,1)]]
+                return [[(1, 0)], [(1, 0), (2, 0), (1, 1)]]
 
         self.assertRaises(ValueError, lambda: problem(p()))
 

--- a/pygmo/core.cpp
+++ b/pygmo/core.cpp
@@ -715,8 +715,7 @@ BOOST_PYTHON_MODULE(core)
     auto ti = pygmo::expose_island<thread_island>("thread_island", pygmo::thread_island_docstring().c_str());
 
     // Archi.
-    bp::class_<archipelago> archi_class("archipelago", pygmo::archipelago_docstring().c_str(),
-                                        bp::init<archipelago::size_type, const island &>());
+    bp::class_<archipelago> archi_class("archipelago", pygmo::archipelago_docstring().c_str(), bp::init<>());
     archi_class.def(repr(bp::self))
         .def_pickle(archipelago_pickle_suite())
         // Copy and deepcopy.


### PR DESCRIPTION
Plus a small round of autopep8.