### PR TITLE
[CI skip] Nsgaii fix

### DIFF
--- a/include/pagmo/algorithms/nsga2.hpp
+++ b/include/pagmo/algorithms/nsga2.hpp
@@ -44,7 +44,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/decompose.hpp>
 #include <pagmo/rng.hpp>
 #include <pagmo/utils/multi_objective.hpp> // crowding_distance, etc..
-#include <pagmo/utils/generic.hpp> // radnom_decision_vector
+#include <pagmo/utils/generic.hpp> // uniform_real_from_range
 
 namespace pagmo
 {
@@ -537,10 +537,10 @@ private:
         for (decltype(D) j = Dc; j < D; ++j) {
             if (drng(m_e) < m_m) {
                 // We need to draw a random integer in [lb, ub]. Since these are floats we
-                // cannot use integer distributions without risking overflows, hence we use the 
-                // pagmo utility which takes care of it random_decision_vector
-                auto mutated = random_decision_vector({{lb[j]},{ub[j]}}, m_e, 1u);
-                child[j] = mutated[0];
+                // cannot use integer distributions without risking overflows, hence we use a real
+                // distribution
+                auto mutated = std::floor(uniform_real_from_range(lb[j], ub[j] + 1, m_e));
+                child[j] = mutated;
             }
         }
     }

--- a/include/pagmo/algorithms/nsga2.hpp
+++ b/include/pagmo/algorithms/nsga2.hpp
@@ -44,6 +44,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/decompose.hpp>
 #include <pagmo/rng.hpp>
 #include <pagmo/utils/multi_objective.hpp> // crowding_distance, etc..
+#include <pagmo/utils/generic.hpp> // radnom_decision_vector
 
 namespace pagmo
 {
@@ -534,10 +535,12 @@ private:
 
         // This implements the integer mutation for an individual
         for (decltype(D) j = Dc; j < D; ++j) {
-            if (drng(m_e) <= m_m) {
-                std::uniform_int_distribution<vector_double::size_type> ra_num(
-                    static_cast<vector_double::size_type>(lb[j]), static_cast<vector_double::size_type>(ub[j]));
-                child[j] = static_cast<double>(ra_num(m_e));
+            if (drng(m_e) < m_m) {
+                // We need to draw a random integer in [lb, ub]. Since these are floats we
+                // cannot use integer disctributions without risking overflows, hence we use the 
+                // pagmo utility which takes care of it random_decision_vector
+                auto mutated = random_decision_vector({{lb[j]},{ub[j]}}, m_e, 1u);
+                child[j] = mutated[0];
             }
         }
     }

--- a/include/pagmo/algorithms/nsga2.hpp
+++ b/include/pagmo/algorithms/nsga2.hpp
@@ -537,7 +537,7 @@ private:
         for (decltype(D) j = Dc; j < D; ++j) {
             if (drng(m_e) < m_m) {
                 // We need to draw a random integer in [lb, ub]. Since these are floats we
-                // cannot use integer disctributions without risking overflows, hence we use the 
+                // cannot use integer distributions without risking overflows, hence we use the 
                 // pagmo utility which takes care of it random_decision_vector
                 auto mutated = random_decision_vector({{lb[j]},{ub[j]}}, m_e, 1u);
                 child[j] = mutated[0];

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -162,11 +162,11 @@ inline vector_double random_decision_vector(const std::pair<vector_double, vecto
         // NOTE: to pursue this approach we need to make sure the upper bound is at least 1 away from infinity
         // otherwise some sick corner case could either result in a non uniform int distrubution or UB
         double lb = bounds.first[i], ub = bounds.second[i];
-        if (!std::isfinite(ub + 1.)) {
-            pagmo_throw(std::invalid_argument,
-                        "The upper bound of the integer part is too large for the decision vector index "
-                            + std::to_string(i));
-        }
+        //if (!std::isfinite(ub + 1.)) {
+        //    pagmo_throw(std::invalid_argument,
+        //                "The upper bound of the integer part is too large for the decision vector index "
+        //                    + std::to_string(i));
+        //}
 
         auto tmp = uniform_real_from_range(lb, ub + 1, r_engine);
         retval[i] = std::floor(tmp);

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -159,15 +159,7 @@ inline vector_double random_decision_vector(const std::pair<vector_double, vecto
         // adding 1 tot he upper bound so that e.g.
         // [0,1] -> draw a float from [0,2] and floor it (that is 0. or 1. with 50%)
         // [3,3] -> draw a float from [3,4] and floor it (that is always 3.)
-        // NOTE: to pursue this approach we need to make sure the upper bound is at least 1 away from infinity
-        // otherwise some sick corner case could either result in a non uniform int distrubution or UB
         double lb = bounds.first[i], ub = bounds.second[i];
-        //if (!std::isfinite(ub + 1.)) {
-        //    pagmo_throw(std::invalid_argument,
-        //                "The upper bound of the integer part is too large for the decision vector index "
-        //                    + std::to_string(i));
-        //}
-
         auto tmp = uniform_real_from_range(lb, ub + 1, r_engine);
         retval[i] = std::floor(tmp);
     }

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -387,6 +387,8 @@ methods:
      ...
    def get_nic(self):
      ...
+   def get_nix(self):
+     ...
    def has_gradient(self):
      ...
    def gradient(self, dv):
@@ -545,6 +547,11 @@ std::string problem_get_nix_docstring()
 Integer dimension of the problem.
 
 This method will return :math:`n_{ix}`, the integer dimension of the problem.
+
+The optional ``get_nix()`` method of the UDP must return the number of equality constraints as an ``int``.
+If the UDP does not implement the ``get_nix()`` method, a zero integer dimension will be assumed.
+The integer dimension returned by the UDP is checked upon the construction
+of a :class:`~pygmo.problem`.
 
 Returns:
     ``int``: the integer dimension of the problem

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -548,7 +548,7 @@ Integer dimension of the problem.
 
 This method will return :math:`n_{ix}`, the integer dimension of the problem.
 
-The optional ``get_nix()`` method of the UDP must return the number of equality constraints as an ``int``.
+The optional ``get_nix()`` method of the UDP must return the problem's integer dimension as an ``int``.
 If the UDP does not implement the ``get_nix()`` method, a zero integer dimension will be assumed.
 The integer dimension returned by the UDP is checked upon the construction
 of a :class:`~pygmo.problem`.
@@ -563,7 +563,7 @@ std::string problem_get_ncx_docstring()
 {
     return R"(get_ncx()
 
-Conrinuous dimension of the problem.
+Continuous dimension of the problem.
 
 This method will return :math:`n_{cx}`, the continuous dimension of the problem.
 


### PR DESCRIPTION
A fix for #138 and #137.

Essentially using the pagmo utility ``generate_random_vector`` to avoid the conversion madness from float to int.