### PR TITLE
Pin the current conda-forge blessed boost version in an attempt to av…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,11 @@ install:
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda clean --all -y
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda update conda -y
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda update --all -y
+# NOTE: here we are pinning the boost and boost-cpp packages versions to the current
+# pinned conda-forge versions, which can be found out at:
+# https://github.com/conda-forge/conda-forge.github.io/blob/master/scripts/pin_the_slow_way.py
+# This ensures that we build with the same boost version we use to build the conda packages.
+# NOTE: these version numbers need to be updated manually.
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda create -y --name pagmo python=3.6 cmake boost=1.65.1 boost-cpp=1.65.1 eigen nlopt
 # NOTE: need to use "call" because otherwise it won't work within an if block.
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] call activate pagmo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda clean --all -y
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda update conda -y
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] conda update --all -y
-- if [%BUILD_TYPE%]==[MSVC_64_Debug] conda create -y --name pagmo python=3.6 cmake boost eigen nlopt
+- if [%BUILD_TYPE%]==[MSVC_64_Debug] conda create -y --name pagmo python=3.6 cmake boost=1.65.1 boost-cpp=1.65.1 eigen nlopt
 # NOTE: need to use "call" because otherwise it won't work within an if block.
 - if [%BUILD_TYPE%]==[MSVC_64_Debug] call activate pagmo
 
@@ -33,7 +33,7 @@ install:
 - if [%BUILD_TYPE%]==[MSVC_64_Python35] conda clean --all -y
 - if [%BUILD_TYPE%]==[MSVC_64_Python35] conda update conda -y
 - if [%BUILD_TYPE%]==[MSVC_64_Python35] conda update --all -y
-- if [%BUILD_TYPE%]==[MSVC_64_Python35] conda create -y --name pagmo python=3.5 cmake boost eigen nlopt numpy cloudpickle ipyparallel
+- if [%BUILD_TYPE%]==[MSVC_64_Python35] conda create -y --name pagmo python=3.5 cmake boost=1.65.1 boost-cpp=1.65.1 eigen nlopt numpy cloudpickle ipyparallel
 - if [%BUILD_TYPE%]==[MSVC_64_Python35] call activate pagmo
 
 - if [%BUILD_TYPE%]==[MSVC_64_Python36] set PATH=C:\Miniconda36-x64\Scripts;%PATH%
@@ -41,7 +41,7 @@ install:
 - if [%BUILD_TYPE%]==[MSVC_64_Python36] conda clean --all -y
 - if [%BUILD_TYPE%]==[MSVC_64_Python36] conda update conda -y 
 - if [%BUILD_TYPE%]==[MSVC_64_Python36] conda update --all -y
-- if [%BUILD_TYPE%]==[MSVC_64_Python36] conda create -y --name pagmo python=3.6 cmake boost eigen nlopt numpy cloudpickle ipyparallel
+- if [%BUILD_TYPE%]==[MSVC_64_Python36] conda create -y --name pagmo python=3.6 cmake boost=1.65.1 boost-cpp=1.65.1 eigen nlopt numpy cloudpickle ipyparallel
 - if [%BUILD_TYPE%]==[MSVC_64_Python36] call activate pagmo
 
 # Rename sh.exe as sh.exe in PATH interferes with MinGW.

--- a/tools/install_deps.sh
+++ b/tools/install_deps.sh
@@ -17,6 +17,11 @@ if [[ "${PAGMO_BUILD}" != manylinux* ]]; then
     bash miniconda.sh -b -p $HOME/miniconda
     conda config --add channels conda-forge --force
 
+    # NOTE: here we are pinning the boost and boost-cpp packages versions to the current
+    # pinned conda-forge versions, which can be found out at:
+    # https://github.com/conda-forge/conda-forge.github.io/blob/master/scripts/pin_the_slow_way.py
+    # This ensures that we build with the same boost version we use to build the conda packages.
+    # NOTE: these version numbers need to be updated manually.
     conda_pkgs="boost=1.65.1 boost-cpp=1.65.1 cmake>=3.2 eigen nlopt ipopt"
 
     if [[ "${PAGMO_BUILD}" == "Python36" || "${PAGMO_BUILD}" == "OSXPython36" ]]; then

--- a/tools/install_deps.sh
+++ b/tools/install_deps.sh
@@ -17,7 +17,7 @@ if [[ "${PAGMO_BUILD}" != manylinux* ]]; then
     bash miniconda.sh -b -p $HOME/miniconda
     conda config --add channels conda-forge --force
 
-    conda_pkgs="boost>=1.55 cmake>=3.2 eigen nlopt ipopt"
+    conda_pkgs="boost=1.65.1 boost-cpp=1.65.1 cmake>=3.2 eigen nlopt ipopt"
 
     if [[ "${PAGMO_BUILD}" == "Python36" || "${PAGMO_BUILD}" == "OSXPython36" ]]; then
         conda_pkgs="$conda_pkgs python=3.6 numpy cloudpickle ipyparallel numba"


### PR DESCRIPTION
…oid issues with Boost 1.66.

And also to provide consistent behaviour with the build pipeline on the feedstock.