### PR TITLE
Add missing import (`setw`)

### DIFF
--- a/include/pagmo/algorithms/ihs.hpp
+++ b/include/pagmo/algorithms/ihs.hpp
@@ -31,6 +31,7 @@ see https://www.gnu.org/licenses/. */
 
 #include <cmath>  // log, etc..
 #include <random> // uniform_int, etc..
+#include <iomanip> // setw
 
 #include <pagmo/io.hpp>
 #include <pagmo/population.hpp>


### PR DESCRIPTION
This PR adds an include that I need to add in order to compile on my machine.