### PR TITLE
Extraction via object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if((NOT PAGMO_BUILD_PAGMO) AND (NOT PAGMO_BUILD_PYGMO))
 endif()
 
 # Main pagmo/pygmo project version.
-set(PAGMO_PROJECT_VERSION 2.9)
+set(PAGMO_PROJECT_VERSION 2.10)
 
 if(PAGMO_BUILD_PAGMO)
     # Initial setup of a pagmo build.

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.10 (unreleased)
+-----------------
+
+Fix
+~~~
+
+- Tentative fix for a pygmo build failure in Cygwin (`#219 <https://github.com/esa/pagmo2/pull/219>`__).
+
+- Various documentation fixes and enhancements (`#217 <https://github.com/esa/pagmo2/pull/217>`__, `#218 <https://github.com/esa/pagmo2/pull/218>`__).
+
 2.9 (2018-08-31)
 ----------------
 

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -4,10 +4,15 @@ Changelog
 2.10 (unreleased)
 -----------------
 
-Fix
+New
 ~~~
 
-- Tentative fix for a pygmo build failure in Cygwin (`#219 <https://github.com/esa/pagmo2/pull/219>`__).
+- Python user-defined classes can now be extracted from their type-erased containers using the
+  Python :class:`object` type (`#219 <https://github.com/esa/pagmo2/pull/219>`__). This allows extraction
+  without knowing the exact type of the object being extracted.
+
+Fix
+~~~
 
 - Various documentation fixes and enhancements (`#217 <https://github.com/esa/pagmo2/pull/217>`__, `#218 <https://github.com/esa/pagmo2/pull/218>`__).
 

--- a/doc/sphinx/docs/python/islands/py_islands.rst
+++ b/doc/sphinx/docs/python/islands/py_islands.rst
@@ -12,6 +12,8 @@ Islands implemented in Python
 .. autoclass:: pygmo.ipyparallel_island
    :members:
 
+.. _py_islands_cpp:
+
 Islands exposed from C++
 -------------------------
 

--- a/pygmo/_algorithm_test.py
+++ b/pygmo/_algorithm_test.py
@@ -141,7 +141,7 @@ class algorithm_test_case(_ut.TestCase):
             population(null_problem(), 5)))
 
     def run_extract_tests(self):
-        from .core import algorithm, _test_algorithm, mbh
+        from .core import algorithm, _test_algorithm, mbh, de
         import sys
 
         # First we try with a C++ test algo.
@@ -205,6 +205,16 @@ class algorithm_test_case(_ut.TestCase):
         self.assertTrue(talgo.get_n() == 1)
         talgo.set_n(12)
         self.assert_(p.extract(talgorithm).get_n() == 12)
+
+        # Check that we can extract Python UDAs also via Python's object type.
+        a = algorithm(talgorithm())
+        self.assertTrue(not a.extract(object) is None)
+        # Check we are referring to the same object.
+        self.assertEqual(id(a.extract(object)), id(a.extract(talgorithm)))
+        # Check that it will not work with exposed C++ algorithms.
+        a = algorithm(de())
+        self.assertTrue(a.extract(object) is None)
+        self.assertTrue(not a.extract(de) is None)
 
     def run_seed_tests(self):
         from .core import algorithm

--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -335,6 +335,18 @@ class island_test_case(_ut.TestCase):
         self.assertTrue(isl.extract(_udi_01) is None)
         self.assertFalse(isl.is_(_udi_01))
 
+        # Check that we can extract Python UDIs also via Python's object type.
+        isl = island(udi=tisland(), algo=null_algorithm(),
+                     prob=null_problem(), size=1)
+        self.assertTrue(not isl.extract(object) is None)
+        # Check we are referring to the same object.
+        self.assertEqual(id(isl.extract(object)), id(isl.extract(tisland)))
+        # Check that it will not work with exposed C++ islands.
+        isl = island(udi=thread_island(), algo=null_algorithm(),
+                     prob=null_problem(), size=1)
+        self.assertTrue(isl.extract(object) is None)
+        self.assertTrue(not isl.extract(thread_island) is None)
+
 
 class mp_island_test_case(_ut.TestCase):
     """Test case for the :class:`~pygmo.mp_island` class.

--- a/pygmo/_patch_algorithm.py
+++ b/pygmo/_patch_algorithm.py
@@ -35,19 +35,46 @@ from .core import algorithm
 
 
 def _algorithm_extract(self, t):
-    """Extract user-defined algorithm instance.
+    """Extract the user-defined algorithm.
 
-    If *t* is the same type of the user-defined algorithm used to construct this algorithm, then a reference to
-    the internal user-defined algorithm will be returned. Otherwise, :data:`None` will be returned.
+    This method allows to extract a reference to the user-defined algorithm (UDA) stored within this
+    :class:`~pygmo.algorithm` instance. The behaviour of this function depends on the value
+    of *t* (which must be a :class:`type`) and on the type of the internal UDA:
+
+    * if the type of the UDA is *t*, then a reference to the UDA will be returned
+      (this mirrors the behaviour of the corresponding C++ method
+      :cpp:func:`pagmo::algorithm::extract()`),
+    * if *t* is :class:`object` and the UDA is a Python object (as opposed to an
+      :ref:`exposed C++ algorithm <py_algorithms_cpp>`), then a reference to the
+      UDA will be returned (this allows to extract a Python UDA without knowing its type),
+    * otherwise, :data:`None` will be returned.
 
     Args:
-        t (type): the type of the user-defined algorithm to extract
+        t (:class:`type`): the type of the user-defined algorithm to extract
 
     Returns:
-        a reference to the internal user-defined algorithm if it is of type *t*, or :data:`None` otherwise
+        a reference to the internal user-defined algorithm, or :data:`None` if the extraction fails
 
     Raises:
-        TypeError: if *t* is not a type
+        TypeError: if *t* is not a :class:`type`
+
+    Examples:
+        >>> import pygmo as pg
+        >>> a1 = pg.algorithm(pg.compass_search())
+        >>> a1.extract(pg.compass_search) # doctest: +SKIP
+        <pygmo.core.compass_search at 0x7f8e4792b670>
+        >>> a1.extract(pg.de) is None
+        True
+        >>> class algo:
+        ...:     def evolve(self, pop):
+        ...:         return pop
+        >>> a2 = pg.algorithm(algo())
+        >>> a2.extract(object) # doctest: +SKIP
+        <__main__.algo at 0x7f8e478c04e0>
+        >>> a2.extract(algo) # doctest: +SKIP
+        <__main__.algo at 0x7f8e478c04e0>
+        >>> a2.extract(pg.de) is None
+        True
 
     """
     if not isinstance(t, type):
@@ -58,19 +85,19 @@ def _algorithm_extract(self, t):
 
 
 def _algorithm_is(self, t):
-    """Check the type of the user-defined algorithm instance.
+    """Check the type of the user-defined algorithm.
 
-    If *t* is the same type of the user-defined algorithm used to construct this algorithm, then :data:`True` will be
-    returned. Otherwise, :data:`False` will be returned.
+    This method returns :data:`False` if :func:`extract(t) <pygmo.algorithm.extract>` returns
+    :data:`None`, and :data:`True` otherwise.
 
     Args:
-        t (type): the type of the user-defined algorithm to extract
+        t (:class:`type`): the type that will be compared to the type of the UDA
 
     Returns:
-        bool: whether the user-defined algorithm is of type *t* or not
+        bool: whether the UDA is of type *t* or not
 
     Raises:
-        TypeError: if *t* is not a type
+        unspecified: any exception thrown by :func:`~pygmo.algorithm.extract()`
 
     """
     return not self.extract(t) is None

--- a/pygmo/_patch_island.py
+++ b/pygmo/_patch_island.py
@@ -35,19 +35,46 @@ from .core import island
 
 
 def _island_extract(self, t):
-    """Extract user-defined island instance.
+    """Extract the user-defined island.
 
-    If *t* is the same type of the user-defined island used to construct this island, then a reference to
-    the internal user-defined island will be returned. Otherwise, :data:`None` will be returned.
+    This method allows to extract a reference to the user-defined island (UDI) stored within this
+    :class:`~pygmo.island` instance. The behaviour of this function depends on the value
+    of *t* (which must be a :class:`type`) and on the type of the internal UDI:
+
+    * if the type of the UDI is *t*, then a reference to the UDI will be returned
+      (this mirrors the behaviour of the corresponding C++ method
+      :cpp:func:`pagmo::island::extract()`),
+    * if *t* is :class:`object` and the UDI is a Python object (as opposed to an
+      :ref:`exposed C++ island <py_islands_cpp>`), then a reference to the
+      UDI will be returned (this allows to extract a Python UDI without knowing its type),
+    * otherwise, :data:`None` will be returned.
 
     Args:
-        t (type): the type of the user-defined island to extract
+        t (:class:`type`): the type of the user-defined island to extract
 
     Returns:
-        a reference to the internal user-defined island if it is of type *t*, or :data:`None` otherwise
+        a reference to the internal user-defined island, or :data:`None` if the extraction fails
 
     Raises:
-        TypeError: if *t* is not a type
+        TypeError: if *t* is not a :class:`type`
+
+    Examples:
+        >>> import pygmo as pg
+        >>> i1 = pg.island(algo=pg.de(), prob=pg.rosenbrock(), size=20, udi=pg.thread_island())
+        >>> i1.extract(pg.thread_island) # doctest: +SKIP
+        <pygmo.core.thread_island at 0x7f8e478e1210>
+        >>> i1.extract(pg.mp_island) is None
+        True
+        >>> class isl:
+        ...:     def run_evolve(self, algo, pop):
+        ...:         return algo, pop
+        >>> i2 = pg.island(algo=pg.de(), prob=pg.rosenbrock(), size=20, udi=isl())
+        >>> i2.extract(object) # doctest: +SKIP
+        <__main__.isl at 0x7f8e478261d0>
+        >>> i2.extract(isl) # doctest: +SKIP
+        <__main__.isl at 0x7f8e478261d0>
+        >>> i2.extract(pg.thread_island) is None
+        True
 
     """
     if not isinstance(t, type):
@@ -58,19 +85,19 @@ def _island_extract(self, t):
 
 
 def _island_is(self, t):
-    """Check the type of the user-defined island instance.
+    """Check the type of the user-defined island.
 
-    If *t* is the same type of the user-defined island used to construct this island, then :data:`True` will be
-    returned. Otherwise, :data:`False` will be returned.
+    This method returns :data:`False` if :func:`extract(t) <pygmo.island.extract>` returns
+    :data:`None`, and :data:`True` otherwise.
 
     Args:
-        t (type): the type of the user-defined island to extract
+        t (:class:`type`): the type that will be compared to the type of the UDI
 
     Returns:
-        bool: whether the user-defined island is of type *t* or not
+        bool: whether the UDI is of type *t* or not
 
     Raises:
-        TypeError: if *t* is not a type
+        unspecified: any exception thrown by :func:`~pygmo.island.extract()`
 
     """
     return not self.extract(t) is None

--- a/pygmo/_patch_problem.py
+++ b/pygmo/_patch_problem.py
@@ -35,19 +35,48 @@ from .core import problem
 
 
 def _problem_extract(self, t):
-    """Extract user-defined problem instance.
+    """Extract the user-defined problem.
 
-    If *t* is the same type of the user-defined problem used to construct this problem, then a reference to
-    the internal user-defined problem will be returned. Otherwise, :data:`None` will be returned.
+    This method allows to extract a reference to the user-defined problem (UDP) stored within this
+    :class:`~pygmo.problem` instance. The behaviour of this function depends on the value
+    of *t* (which must be a :class:`type`) and on the type of the internal UDP:
+
+    * if the type of the UDP is *t*, then a reference to the UDP will be returned
+      (this mirrors the behaviour of the corresponding C++ method
+      :cpp:func:`pagmo::problem::extract()`),
+    * if *t* is :class:`object` and the UDP is a Python object (as opposed to an
+      :ref:`exposed C++ problem <py_problems_cpp>`), then a reference to the
+      UDP will be returned (this allows to extract a Python UDP without knowing its type),
+    * otherwise, :data:`None` will be returned.
 
     Args:
-        t (type): the type of the user-defined problem to extract
+        t (:class:`type`): the type of the user-defined problem to extract
 
     Returns:
-        a reference to the internal user-defined problem if it is of type *t*, or :data:`None` otherwise
+        a reference to the internal user-defined problem, or :data:`None` if the extraction fails
 
     Raises:
-        TypeError: if *t* is not a type
+        TypeError: if *t* is not a :class:`type`
+
+    Examples:
+        >>> import pygmo as pg
+        >>> p1 = pg.problem(pg.rosenbrock())
+        >>> p1.extract(pg.rosenbrock) # doctest: +SKIP
+        <pygmo.core.rosenbrock at 0x7f56b870fd50>
+        >>> p1.extract(pg.ackley) is None
+        True
+        >>> class prob:
+        ...:     def fitness(self, x):
+        ...:         return x[0]
+        ...:     def get_bounds(self):
+        ...:         return ([0],[1])
+        >>> p2 = pg.problem(prob())
+        >>> p2.extract(object) # doctest: +SKIP
+        <__main__.prob at 0x7f56a66b6588>
+        >>> p2.extract(prob) # doctest: +SKIP
+        <__main__.prob at 0x7f56a66b6588>
+        >>> p2.extract(pg.rosenbrock) is None
+        True
 
     """
     if not isinstance(t, type):
@@ -58,19 +87,19 @@ def _problem_extract(self, t):
 
 
 def _problem_is(self, t):
-    """Check the type of the user-defined problem instance.
+    """Check the type of the user-defined problem.
 
-    If *t* is the same type of the user-defined problem used to construct this problem, then :data:`True` will be
-    returned. Otherwise, :data:`False` will be returned.
+    This method returns :data:`False` if :func:`extract(t) <pygmo.problem.extract>` returns
+    :data:`None`, and :data:`True` otherwise.
 
     Args:
-        t (type): the type of the user-defined problem to extract
+        t (:class:`type`): the type that will be compared to the type of the UDP
 
     Returns:
-        bool: whether the user-defined problem is of type *t* or not
+        bool: whether the UDP is of type *t* or not
 
     Raises:
-        TypeError: if *t* is not a type
+        unspecified: any exception thrown by :func:`~pygmo.problem.extract()`
 
     """
     return not self.extract(t) is None

--- a/pygmo/_patch_problem.py
+++ b/pygmo/_patch_problem.py
@@ -67,7 +67,7 @@ def _problem_extract(self, t):
         True
         >>> class prob:
         ...:     def fitness(self, x):
-        ...:         return x[0]
+        ...:         return [x[0]]
         ...:     def get_bounds(self):
         ...:         return ([0],[1])
         >>> p2 = pg.problem(prob())

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -551,7 +551,7 @@ class problem_test_case(_ut.TestCase):
         self.assertRaises(ValueError, lambda: prob.fitness([1, 2]))
 
     def run_extract_tests(self):
-        from .core import problem, translate, _test_problem, decompose
+        from .core import problem, translate, _test_problem, decompose, rosenbrock
         import sys
 
         # First we try with a C++ test problem.
@@ -680,6 +680,16 @@ class problem_test_case(_ut.TestCase):
         del test_prob
         # Verify the refcount of p drops back.
         self.assert_(sys.getrefcount(p) == rc)
+
+        # Check that we can extract Python UDPs also via Python's object type.
+        p = problem(tproblem())
+        self.assertTrue(not p.extract(object) is None)
+        # Check we are referring to the same object.
+        self.assertEqual(id(p.extract(object)), id(p.extract(tproblem)))
+        # Check that it will not work with exposed C++ problems.
+        p = problem(rosenbrock())
+        self.assertTrue(p.extract(object) is None)
+        self.assertTrue(not p.extract(rosenbrock) is None)
 
     def run_nec_nic_tests(self):
         from .core import problem

--- a/pygmo/common_utils.hpp
+++ b/pygmo/common_utils.hpp
@@ -611,17 +611,17 @@ template <typename C>
 inline bp::object generic_py_extract(C &c, const bp::object &t)
 {
     auto ptr = c.template extract<bp::object>();
-    // NOTE: this function must be used only if we are
-    // sure the user-defined entity is a Python object.
-    assert(ptr);
-    if (t == builtin().attr("object") || t == type(*ptr)) {
-        // Either the user supplied as t the builtin 'object' type
-        // (which we use as a wildcard for any Python type), or the type
-        // passed in by the user is the exact type of the user-defined
-        // entity. Let's return the extracted object.
+    if (ptr && (t == type(*ptr) || t == builtin().attr("object"))) {
+        // c contains a user-defined pythonic entity and either:
+        // - the type passed in by the user is the exact type of the user-defined
+        //   entity, or
+        // - the user supplied as t the builtin 'object' type (which we use as a
+        //   wildcard for any Python type).
+        // Let's return the extracted object.
         return *ptr;
     }
-    // The user specified the wrong type, return None.
+    // Either the user-defined entity is not pythonic, or the user specified the
+    // wrong type. Return None.
     return bp::object{};
 }
 

--- a/pygmo/common_utils.hpp
+++ b/pygmo/common_utils.hpp
@@ -611,10 +611,18 @@ template <typename C>
 inline bp::object generic_py_extract(C &c, const bp::object &t)
 {
     auto ptr = c.template extract<bp::object>();
-    if (!ptr || type(*ptr) != t) {
-        return bp::object{};
+    // NOTE: this function must be used only if we are
+    // sure the user-defined entity is a Python object.
+    assert(ptr);
+    if (t == builtin().attr("object") || t == type(*ptr)) {
+        // Either the user supplied as t the builtin 'object' type
+        // (which we use as a wildcard for any Python type), or the type
+        // passed in by the user is the exact type of the user-defined
+        // entity. Let's return the extracted object.
+        return *ptr;
     }
-    return *ptr;
+    // The user specified the wrong type, return None.
+    return bp::object{};
 }
 
 // Detail implementation of the tuple conversion below.


### PR DESCRIPTION
This PR adds support for extracting Python user-defined entities without knowing their exact type.

For example, given the Python UDA

```python
class algo:
   def evolve(self, pop):
      return pop
```

one can now do:

```python
>>> a = pg.algorithm(algo())
>>> a.extract(object)
<__main__.algo at 0x7f8e478c04e0>
```

whereas previously one would need to write, instead,

```python
>>> a = pg.algorithm(algo())
>>> a.extract(algo)
<__main__.algo at 0x7f8e478c04e0>
```

This second syntax still works.

For exposed C++ user-defined classes, nothing changes (i.e., the exact correct type must still be provided for a successful extraction).

Two reasons why this might be useful.

First, working with pythonic classes is now slightly easier, as one does not need to remember the exact type for extraction.

Second, this can be useful to work around extraction issues when working in an interactive session.

Right now, if one defines a new UDP in an interactive session and then does the following

```python
In [1]: import pygmo as pg

In [2]: class prob:
   ...:     def fitness(self, x):
   ...:         return [x[0]]
   ...:     def get_bounds(self):
   ...:         return ([0],[1])
   ...:     

In [3]: isl = pg.island(prob=prob(), algo=pg.de(100), size=20)

In [4]: isl.evolve();isl.wait_check()
```

then, unexpectedly,

```python
In [5]: isl.get_population().problem.extract(prob) is None
True
```

That is, after evolution has been dispatched to an external process, the extraction of the problem via its original type fails. This happens because of various internal details of how Python serialisation works (specifically, the ``prob`` class that gets defined in the ``__main__`` module of the remote process is not of the same type as the original ``prob`` class). This may or may not be fixed in the future.

With ``object``-based extraction, we can now do instead

```python
In [6]: isl.get_population().problem.extract(object)
<__main__.prob at 0x7f48585d2b38>
```

and this will now work as intended.