### PR TITLE
Proposed fix for #240

### DIFF
--- a/include/pagmo/algorithms/moead.hpp
+++ b/include/pagmo/algorithms/moead.hpp
@@ -43,7 +43,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/decompose.hpp>
 #include <pagmo/rng.hpp>
-#include <pagmo/utils/generic.hpp>         // kNN
+#include <pagmo/utils/generic.hpp>         // kNN, some_bound_is_equal
 #include <pagmo/utils/multi_objective.hpp> // ideal
 
 namespace pagmo
@@ -176,6 +176,9 @@ public:
         // PREAMBLE-------------------------------------------------------------------------------------------------
         // We start by checking that the problem is suitable for this
         // particular algorithm.
+        if (detail::some_bound_is_equal(prob)) {
+            pagmo_throw(std::invalid_argument, get_name() + " cannot work on problems having a lower bound equal to an upper bound. Check your bounds.");
+        }
         if (!NP) {
             pagmo_throw(std::invalid_argument, get_name() + " cannot work on an empty population");
         }

--- a/include/pagmo/algorithms/nsga2.hpp
+++ b/include/pagmo/algorithms/nsga2.hpp
@@ -43,7 +43,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/decompose.hpp>
 #include <pagmo/rng.hpp>
-#include <pagmo/utils/generic.hpp>         // uniform_real_from_range
+#include <pagmo/utils/generic.hpp>         // uniform_real_from_range, some_bound_is_equal
 #include <pagmo/utils/multi_objective.hpp> // crowding_distance, etc..
 
 namespace pagmo
@@ -135,6 +135,9 @@ public:
         // PREAMBLE-------------------------------------------------------------------------------------------------
         // We start by checking that the problem is suitable for this
         // particular algorithm.
+        if (detail::some_bound_is_equal(prob)) {
+            pagmo_throw(std::invalid_argument, get_name() + " cannot work on problems having a lower bound equal to an upper bound. Check your bounds.");
+        }
         if (prob.is_stochastic()) {
             pagmo_throw(std::invalid_argument,
                         "The problem appears to be stochastic " + get_name() + " cannot deal with it");

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -51,6 +51,25 @@ see https://www.gnu.org/licenses/. */
 namespace pagmo
 {
 
+namespace detail
+{
+/// Checks that all elements of the problem bounds are not equal
+inline bool some_bound_is_equal(const problem &prob)
+{
+    // Some variable renaming
+    const auto bounds = prob.get_bounds();
+    const auto &lb = bounds.first;
+    const auto &ub = bounds.second;
+    // Since the bounds are extracted from problem we can be sure they have equal length
+    for (decltype(lb.size()) i = 0u; i < lb.size(); ++i) {
+        if (lb[i] == ub[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+}
+
 /// Generates a random number within some lower and upper bounds
 /**
  * Creates a random number within a closed range. If

--- a/tests/moead.cpp
+++ b/tests/moead.cpp
@@ -133,6 +133,23 @@ struct mo_many {
     }
 };
 
+struct mo_equal_bounds {
+    /// Fitness
+    vector_double fitness(const vector_double &) const
+    {
+        return {0., 0.};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2u;
+    }
+    /// Problem bounds
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0., 0.}, {1., 0.}};
+    }
+};
+
 BOOST_AUTO_TEST_CASE(moead_evolve_test)
 {
     // Here we only test that evolution is deterministic if the
@@ -160,6 +177,8 @@ BOOST_AUTO_TEST_CASE(moead_evolve_test)
     BOOST_CHECK(user_algo1.get_log() == user_algo2.get_log());
 
     // We then check that the method evolve fails when called on unsuitable problems (populations)
+    // Some bound is equal
+    BOOST_CHECK_THROW(moead{10u}.evolve(population{problem{mo_equal_bounds{}}, 0u}), std::invalid_argument);
     // Empty population.
     BOOST_CHECK_THROW(moead{10u}.evolve(population{problem{rosenbrock{}}, 0u}), std::invalid_argument);
     // Single objective problem

--- a/tests/nsga2.cpp
+++ b/tests/nsga2.cpp
@@ -71,9 +71,29 @@ BOOST_AUTO_TEST_CASE(nsga2_algorithm_construction)
     BOOST_CHECK_THROW((nsga2{1u, .95, 10., 0.01, .98, 32u}), std::invalid_argument);
 }
 
+
+struct mo_equal_bounds {
+    /// Fitness
+    vector_double fitness(const vector_double &) const
+    {
+        return {0., 0.};
+    }
+    vector_double::size_type get_nobj() const
+    {
+        return 2u;
+    }
+    /// Problem bounds
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {{0., 0.}, {1., 0.}};
+    }
+};
+
 BOOST_AUTO_TEST_CASE(nsga2_evolve_test)
 {
     // We check that the problem is checked to be suitable
+    // Some bound is equal
+    BOOST_CHECK_THROW(nsga2{10u}.evolve(population{problem{mo_equal_bounds{}}, 0u}), std::invalid_argument);
     // stochastic
     BOOST_CHECK_THROW((nsga2{}.evolve(population{inventory{}, 5u, 23u})), std::invalid_argument);
     // constrained prob


### PR DESCRIPTION
Introducing in detail a check for all upper bounds to be strictly larger than lower bounds. This is called in the preamble of all algorithms that cannot deal with zero width of the bound box. For the moment MOEAD and NSGAII. More algorithms could be needing this, did not test all of them.