### PR TITLE
(pygmo) Prevent problem/algorithm to be usable as UDP/UDA

### DIFF
--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -4,13 +4,19 @@ Changelog
 2.11 (unreleased)
 -----------------
 
+Changes
+~~~~~~~
+
+- **BREAKING**: :class:`pygmo.problem` and :class:`pygmo.algorithm` cannot be used as UDPs and UDAs any more.
+  This change makes the behaviour of pygmo consistent with the behaviour of pagmo (`#248 <https://github.com/esa/pagmo2/pull/248>`__).
+
 Fix
 ~~~
 
 - Fix the behaviour of NSGA2 and MOEAD when the problem has equal lower/upper bounds (`#244 <https://github.com/esa/pagmo2/pull/244>`__).
 
-- Various documentation, build system and unit testing improvements (`#243 <https://github.com/esa/pagmo2/pull/243>`__,
-  `#245 <https://github.com/esa/pagmo2/pull/245>`__)
+- Various documentation, build system and unit testing fixes/improvements (`#243 <https://github.com/esa/pagmo2/pull/243>`__,
+  `#245 <https://github.com/esa/pagmo2/pull/245>`__, `#248 <https://github.com/esa/pagmo2/pull/248>`__).
 
 - The :cpp:class:`~pagmo::fork_island` UDI now properly cleans up zombie processes (`#242 <https://github.com/esa/pagmo2/pull/242>`__).
 

--- a/doc/sphinx/docs/cpp/islands/fork_island.rst
+++ b/doc/sphinx/docs/cpp/islands/fork_island.rst
@@ -51,8 +51,8 @@ Fork island
    .. cpp:function:: fork_island(const fork_island &)
    .. cpp:function:: fork_island(fork_island &&) noexcept
 
-   :cpp:class:`~pagmo::fork_island` is default, copy and move-constructible. The copy and move constructor are equivalent
-   to the default constructor.
+      :cpp:class:`~pagmo::fork_island` is default, copy and move-constructible. The copy and move constructor are equivalent
+      to the default constructor.
 
    .. cpp:function:: void run_evolve(island &isl) const
 
@@ -94,10 +94,3 @@ Fork island
       Note that :cpp:class:`~pagmo::fork_island` is stateless, and thus this (de)serialisation function is empty and performs no work.
 
 .. cpp:namespace-pop::
-
-Types
------
-
-.. cpp:type:: pid_t
-
-   The POSIX type used to represent a process ID. It is an alias for a fundamental signed integral type.

--- a/doc/sphinx/docs/problem_list.rst
+++ b/doc/sphinx/docs/problem_list.rst
@@ -23,7 +23,7 @@ Common Name                                                Docs of the C++ class
 ========================================================== ========================================= ========================================= ===============
 Ackley                                                     :cpp:class:`pagmo::ackley`                :class:`pygmo.ackley`                     S-U
 Griewank                                                   :cpp:class:`pagmo::griewank`              :class:`pygmo.griewank`                   S-U
-Hock Schittkowsky 71                                       :cpp:class:`pagmo::hock_shittkowski_71`   :class:`pygmo.hock_shittkowski_71`        S-C
+Hock Schittkowsky 71                                       :cpp:class:`pagmo::hock_schittkowsky_71`  :class:`pygmo.hock_schittkowsky_71`       S-C
 Inventory                                                  :cpp:class:`pagmo::inventory`             :class:`pygmo.inventory`                  S-U-sto
 Luksan Vlcek 1                                             :cpp:class:`pagmo::luksan_vlcek1`         :class:`pygmo.luksan_vlcek1`              S-C
 Rastrigin                                                  :cpp:class:`pagmo::rastrigin`             :class:`pygmo.rastrigin`                  S-U

--- a/doc/sphinx/docs/python/tutorials/coding_udp_minlp.rst
+++ b/doc/sphinx/docs/python/tutorials/coding_udp_minlp.rst
@@ -170,7 +170,7 @@ possible cases we thus fix the box bounds on the last two variables. In case :ma
 We found a feasible solution! Note that in the other 3 cases no feasible solution exists.
 
 .. note::
-   The solution strategy above is, in general, flawed in assuming the best solution of the relaxed problem is colse to the 
+   The solution strategy above is, in general, flawed in assuming the best solution of the relaxed problem is close to the
    the full MINLP problem solution. More sophisticated techniques would instead search the combinatorial part more exhaustvely.
    We used here this approach only to show how simple is, in pygmo, to define and solve the relaxed problem and
    to then feedback the optimal decision vector into a MINLP solution strategy. 

--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -557,7 +557,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    const T *extract() const
+    const T *extract() const noexcept
     {
         auto p = dynamic_cast<const detail::algo_inner<T> *>(ptr());
         return p == nullptr ? nullptr : &(p->m_value);
@@ -590,7 +590,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    T *extract()
+    T *extract() noexcept
     {
         auto p = dynamic_cast<detail::algo_inner<T> *>(ptr());
         return p == nullptr ? nullptr : &(p->m_value);
@@ -601,7 +601,7 @@ public:
      * @return \p true if the user-defined algorithm is \p T, \p false otherwise.
      */
     template <typename T>
-    bool is() const
+    bool is() const noexcept
     {
         return extract<T>() != nullptr;
     }

--- a/include/pagmo/island.hpp
+++ b/include/pagmo/island.hpp
@@ -982,7 +982,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    const T *extract() const
+    const T *extract() const noexcept
     {
         auto isl = dynamic_cast<const detail::isl_inner<T> *>(m_ptr->isl_ptr.get());
         return isl == nullptr ? nullptr : &(isl->m_value);
@@ -1011,7 +1011,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    T *extract()
+    T *extract() noexcept
     {
         auto isl = dynamic_cast<detail::isl_inner<T> *>(m_ptr->isl_ptr.get());
         return isl == nullptr ? nullptr : &(isl->m_value);
@@ -1021,7 +1021,7 @@ public:
      * @return \p true if the UDI used in construction is of type \p T, \p false otherwise.
      */
     template <typename T>
-    bool is() const
+    bool is() const noexcept
     {
         return extract<T>() != nullptr;
     }

--- a/include/pagmo/island.hpp
+++ b/include/pagmo/island.hpp
@@ -802,6 +802,10 @@ public:
     }
 
 private:
+    // NOTE: here and elsewhere, we don't have to put the constraint that Isl is not pagmo::island,
+    // like we do in pagmo::problem/pagmo::algorithm: pagmo::island does not satisfy the interface
+    // requirements of a UDI, thus it is impossible to create a pagmo::island containing another
+    // pagmo::island as a UDI.
     template <typename Isl, typename Algo, typename Pop>
     using isl_algo_pop_enabler
         = enable_if_t<is_udi<uncvref_t<Isl>>::value && std::is_constructible<algorithm, Algo &&>::value

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -1328,7 +1328,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    const T *extract() const
+    const T *extract() const noexcept
     {
         auto p = dynamic_cast<const detail::prob_inner<T> *>(ptr());
         return p == nullptr ? nullptr : &(p->m_value);
@@ -1358,7 +1358,7 @@ public:
      * in the constructor.
      */
     template <typename T>
-    T *extract()
+    T *extract() noexcept
     {
         auto p = dynamic_cast<detail::prob_inner<T> *>(ptr());
         return p == nullptr ? nullptr : &(p->m_value);
@@ -1369,7 +1369,7 @@ public:
      * @return \p true if the UDP used in construction is of type \p T, \p false otherwise.
      */
     template <typename T>
-    bool is() const
+    bool is() const noexcept
     {
         return extract<T>() != nullptr;
     }

--- a/pygmo/_algorithm_test.py
+++ b/pygmo/_algorithm_test.py
@@ -140,6 +140,13 @@ class algorithm_test_case(_ut.TestCase):
         self.assertRaises(TypeError, lambda: algo.evolve(
             population(null_problem(), 5)))
 
+        # Test that construction from another pygmo.algorithm fails.
+        with self.assertRaises(TypeError) as cm:
+            algorithm(algo)
+        err = cm.exception
+        self.assertTrue(
+            "the construction of a pygmo.algorithm from another pygmo.algorithm is disabled, please use the standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.algorithm" in str(err))
+
     def run_extract_tests(self):
         from .core import algorithm, _test_algorithm, mbh, de
         import sys

--- a/pygmo/_algorithm_test.py
+++ b/pygmo/_algorithm_test.py
@@ -145,7 +145,7 @@ class algorithm_test_case(_ut.TestCase):
             algorithm(algo)
         err = cm.exception
         self.assertTrue(
-            "the construction of a pygmo.algorithm from another pygmo.algorithm is disabled, please use the standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.algorithm" in str(err))
+            "a pygmo.algorithm cannot be used as a UDA for another pygmo.algorithm (if you need to copy an algorithm please use the standard Python copy()/deepcopy() functions)" in str(err))
 
     def run_extract_tests(self):
         from .core import algorithm, _test_algorithm, mbh, de

--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -174,6 +174,10 @@ class island_test_case(_ut.TestCase):
         self.assertTrue(
             "the 'run_evolve()' method of a user-defined island must return a tuple, but it returned an object of type '" in str(err))
 
+        # Test that construction from another pygmo.island fails.
+        with self.assertRaises(NotImplementedError) as cm:
+            island(prob=rosenbrock(), udi=isl, size=11, algo=de(), seed=15)
+
     def run_concurrent_access_tests(self):
         import threading as thr
         from .core import island, de, rosenbrock

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -291,7 +291,7 @@ class problem_test_case(_ut.TestCase):
             problem(prob)
         err = cm.exception
         self.assertTrue(
-            "the construction of a pygmo.problem from another pygmo.problem is disabled, please use the standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.problem" in str(err))
+            "a pygmo.problem cannot be used as a UDP for another pygmo.problem (if you need to copy a problem please use the standard Python copy()/deepcopy() functions)" in str(err))
 
     def run_ctol_tests(self):
         from .core import problem

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -286,6 +286,13 @@ class problem_test_case(_ut.TestCase):
         prob = problem(p())
         self.assert_(all(prob.fitness([1, 2]) == array([42])))
 
+        # Test that construction from another pygmo.problem fails.
+        with self.assertRaises(TypeError) as cm:
+            problem(prob)
+        err = cm.exception
+        self.assertTrue(
+            "the construction of a pygmo.problem from another pygmo.problem is disabled, please use the standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.problem" in str(err))
+
     def run_ctol_tests(self):
         from .core import problem
         from numpy import array

--- a/pygmo/algorithm.hpp
+++ b/pygmo/algorithm.hpp
@@ -86,8 +86,8 @@ struct algo_inner<bp::object> final : algo_inner_base, pygmo::common_base {
         if (pygmo::type(o) == bp::import("pygmo").attr("algorithm")) {
             pygmo_throw(
                 PyExc_TypeError,
-                ("the construction of a pygmo.algorithm from another pygmo.algorithm is disabled, please use the "
-                 "standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.algorithm"));
+                ("a pygmo.algorithm cannot be used as a UDA for another pygmo.algorithm (if you need to copy an "
+                 "algorithm please use the standard Python copy()/deepcopy() functions)"));
         }
         // Check that o is an instance of a class, and not a type.
         check_not_type(o, "algorithm");

--- a/pygmo/algorithm.hpp
+++ b/pygmo/algorithm.hpp
@@ -74,6 +74,22 @@ struct algo_inner<bp::object> final : algo_inner_base, pygmo::common_base {
     algo_inner &operator=(algo_inner &&) = delete;
     explicit algo_inner(const bp::object &o)
     {
+        // Forbid the use of a pygmo.algorithm as a UDA.
+        // The motivation here is consistency with C++. In C++, the use of
+        // a pagmo::algorithm as a UDA is forbidden and prevented by the fact
+        // that the generic constructor from UDA is disabled if the input
+        // object is a pagmo::algorithm (the copy/move constructor is
+        // invoked instead). In order to achieve an equivalent behaviour
+        // in pygmo, we throw an error if o is a algorithm, and instruct
+        // the user to employ the standard copy/deepcopy facilities
+        // for creating a copy of the input algorithm.
+        if (pygmo::type(o) == bp::import("pygmo").attr("algorithm")) {
+            pygmo_throw(
+                PyExc_TypeError,
+                ("the construction of a pygmo.algorithm from another pygmo.algorithm is disabled, please use the "
+                 "standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.algorithm"));
+        }
+        // Check that o is an instance of a class, and not a type.
         check_not_type(o, "algorithm");
         check_mandatory_method(o, "evolve", "algorithm");
         m_value = pygmo::deepcopy(o);

--- a/pygmo/island.hpp
+++ b/pygmo/island.hpp
@@ -79,6 +79,11 @@ struct isl_inner<bp::object> final : isl_inner_base, pygmo::common_base {
     isl_inner &operator=(isl_inner &&) = delete;
     explicit isl_inner(const bp::object &o)
     {
+        // NOTE: unlike pygmo.problem/algorithm, we don't have to enforce
+        // that o is not a pygmo.island, because pygmo.island does not satisfy
+        // the UDI interface and thus check_mandatory_method() below will fail
+        // if o is a pygmo.island.
+        // Check that o is an instance of a class, and not a type.
         check_not_type(o, "island");
         check_mandatory_method(o, "run_evolve", "island");
         m_value = pygmo::deepcopy(o);

--- a/pygmo/problem.hpp
+++ b/pygmo/problem.hpp
@@ -102,8 +102,8 @@ struct prob_inner<bp::object> final : prob_inner_base, pygmo::common_base {
         // for creating a copy of the input problem.
         if (pygmo::type(o) == bp::import("pygmo").attr("problem")) {
             pygmo_throw(PyExc_TypeError,
-                        ("the construction of a pygmo.problem from another pygmo.problem is disabled, please use the "
-                         "standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.problem"));
+                        ("a pygmo.problem cannot be used as a UDP for another pygmo.problem (if you need to copy a "
+                         "problem please use the standard Python copy()/deepcopy() functions)"));
         }
         // Check that o is an instance of a class, and not a type.
         check_not_type(o, "problem");

--- a/pygmo/problem.hpp
+++ b/pygmo/problem.hpp
@@ -35,6 +35,7 @@ see https://www.gnu.org/licenses/. */
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/extract.hpp>
+#include <boost/python/import.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/object.hpp>
 #include <boost/python/stl_iterator.hpp>
@@ -90,6 +91,21 @@ struct prob_inner<bp::object> final : prob_inner_base, pygmo::common_base {
     prob_inner &operator=(prob_inner &&) = delete;
     explicit prob_inner(const bp::object &o)
     {
+        // Forbid the use of a pygmo.problem as a UDP.
+        // The motivation here is consistency with C++. In C++, the use of
+        // a pagmo::problem as a UDP is forbidden and prevented by the fact
+        // that the generic constructor from UDP is disabled if the input
+        // object is a pagmo::problem (the copy/move constructor is
+        // invoked instead). In order to achieve an equivalent behaviour
+        // in pygmo, we throw an error if o is a problem, and instruct
+        // the user to employ the standard copy/deepcopy facilities
+        // for creating a copy of the input problem.
+        if (pygmo::type(o) == bp::import("pygmo").attr("problem")) {
+            pygmo_throw(PyExc_TypeError,
+                        ("the construction of a pygmo.problem from another pygmo.problem is disabled, please use the "
+                         "standard Python copy()/deepcopy() functions if you need to copy-construct a pygmo.problem"));
+        }
+        // Check that o is an instance of a class, and not a type.
         check_not_type(o, "problem");
         // Check the presence of the mandatory methods (these are static asserts
         // in the C++ counterpart).


### PR DESCRIPTION
In C++, one cannot use ``pagmo::problem`` as a UDP - if one tries, the effect will be to invoke the copy/move constructor of ``pagmo::problem`` instead.

In pygmo, the behaviour before this PR was that a ``pygmo.problem`` could be used as a UDP because ``pygmo.problem`` does satisfy the UDP interface requirements, and there was nothing explicitly preventing the use of a ``pygmo.problem`` as a UDP. This PR makes the behaviour in Python consistent with the behaviour in C++ by explicitly forbidding the use of a ``pygmo.problem`` as a UDP.

(all the above applies to algorithm and UDAs as well)

The PR contains also some small doc fixes.

EDIT: it also contains new ``noexcept`` specifiers for the extraction facilities in problem, algorithm and island (this bit came out while developing the batch fitness capability).