### PR TITLE
Rework the rng logic in generic.hpp

### DIFF
--- a/doc/sphinx/docs/cpp/miscellanea/generic.rst
+++ b/doc/sphinx/docs/cpp/miscellanea/generic.rst
@@ -7,15 +7,15 @@ A number of utilities to compute quantities that are of general relevance.
 
 --------------------------------------------------------------------------
 
-.. doxygenfunction:: uniform_real_from_range
+.. doxygenfunction:: pagmo::uniform_real_from_range
 
 --------------------------------------------------------------------------
 
-.. doxygenfunction:: pagmo::random_decision_vector(const std::pair<vector_double, vector_double>&, detail::random_engine_type&, vector_double::size_type)
+.. doxygenfunction:: pagmo::uniform_integral_from_range
 
 --------------------------------------------------------------------------
 
-.. doxygenfunction:: pagmo::random_decision_vector(const vector_double&, const vector_double&, detail::random_engine_type&, vector_double::size_type)
+.. doxygenfunction:: pagmo::random_decision_vector
 
 --------------------------------------------------------------------------
 

--- a/include/pagmo/algorithms/ihs.hpp
+++ b/include/pagmo/algorithms/ihs.hpp
@@ -225,7 +225,7 @@ public:
                     }
                 } else {
                     // Pick randomly within the bounds.
-                    new_x[i] = std::uniform_real_distribution<>(lb[i], ub[i])(m_e);
+                    new_x[i] = uniform_real_from_range(lb[i], ub[i], m_e);
                 }
             }
 
@@ -236,17 +236,15 @@ public:
                     new_x[i] = pop.get_x()[uni_int(m_e)][i];
                     // Do pitch adjustment with ppar_cur probability.
                     if (drng(m_e) < ppar_cur) {
-                        // This generates minimum 1 and, only if bw_cur ==1 the pitch will be bigger
+                        // This generates minimum 1 and, only if bw_cur == 1 the pitch will be bigger
                         // than the width. Which is anyway dealt with later by the bound reflection
-                        unsigned pitch = static_cast<unsigned>(1u + bw_cur * lu_diff[i]);
+                        const double pitch = std::trunc(1 + bw_cur * lu_diff[i]);
                         // Randomly, add or subtract pitch from the current chromosome element.
-                        new_x[i] += std::floor(std::uniform_real_distribution<>(new_x[i] - pitch, new_x[i] + pitch + 1u)(m_e));
+                        new_x[i] += uniform_integral_from_range(new_x[i] - pitch, new_x[i] + pitch, m_e);
                     }
                 } else {
-                    // We need to draw a random integer in [lb, ub]. Since these are floats we
-                    // cannot use integer distributions without risking overflows, hence we use a real
-                    // distribution
-                    new_x[i] = std::floor(uniform_real_from_range(lb[i], ub[i] + 1u, m_e));
+                    // Draw a random integer in [lb, ub].
+                    new_x[i] = uniform_integral_from_range(lb[i], ub[i], m_e);
                 }
             }
 

--- a/include/pagmo/algorithms/nsga2.hpp
+++ b/include/pagmo/algorithms/nsga2.hpp
@@ -136,7 +136,10 @@ public:
         // We start by checking that the problem is suitable for this
         // particular algorithm.
         if (detail::some_bound_is_equal(prob)) {
-            pagmo_throw(std::invalid_argument, get_name() + " cannot work on problems having a lower bound equal to an upper bound. Check your bounds.");
+            pagmo_throw(
+                std::invalid_argument,
+                get_name()
+                    + " cannot work on problems having a lower bound equal to an upper bound. Check your bounds.");
         }
         if (prob.is_stochastic()) {
             pagmo_throw(std::invalid_argument,
@@ -539,10 +542,8 @@ private:
         // This implements the integer mutation for an individual
         for (decltype(D) j = Dc; j < D; ++j) {
             if (drng(m_e) < m_m) {
-                // We need to draw a random integer in [lb, ub]. Since these are floats we
-                // cannot use integer distributions without risking overflows, hence we use a real
-                // distribution
-                auto mutated = std::floor(uniform_real_from_range(lb[j], ub[j] + 1, m_e));
+                // We need to draw a random integer in [lb, ub].
+                auto mutated = uniform_integral_from_range(lb[j], ub[j], m_e);
                 child[j] = mutated;
             }
         }

--- a/include/pagmo/algorithms/simulated_annealing.hpp
+++ b/include/pagmo/algorithms/simulated_annealing.hpp
@@ -42,6 +42,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/io.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/rng.hpp>
+#include <pagmo/utils/generic.hpp>
 
 namespace pagmo
 {
@@ -218,8 +219,8 @@ public:
                         nter = (nter + 1u) % dim;
                         // We modify the current point by mutating its nter component within the adaptive step
                         auto width = step[nter] * (ub[nter] - lb[nter]);
-                        xNEW[nter] = std::uniform_real_distribution<>(std::max(xOLD[nter] - width, lb[nter]),
-                                                                      std::min(xOLD[nter] + width, ub[nter]))(m_e);
+                        xNEW[nter] = uniform_real_from_range(std::max(xOLD[nter] - width, lb[nter]),
+                                                             std::min(xOLD[nter] + width, ub[nter]), m_e);
                         // And we valuate the objective function for the new point
                         fNEW = prob.fitness(xNEW);
                         // We decide wether to accept or discard the point

--- a/include/pagmo/population.hpp
+++ b/include/pagmo/population.hpp
@@ -318,7 +318,7 @@ public:
      */
     vector_double random_decision_vector() const
     {
-        return pagmo::random_decision_vector(m_prob.get_bounds(), m_e, get_problem().get_nix());
+        return pagmo::random_decision_vector(m_prob, m_e);
     }
 
     /// Index of the best individual

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -1741,6 +1741,24 @@ public:
         return std::make_pair(m_lb, m_ub);
     }
 
+    /// Lower bounds.
+    /**
+     * @return a const reference to the vector of lower box bounds for this problem.
+     */
+    const vector_double &get_lb() const
+    {
+        return m_lb;
+    }
+
+    /// Upper bounds.
+    /**
+     * @return a const reference to the vector of upper box bounds for this problem.
+     */
+    const vector_double &get_ub() const
+    {
+        return m_ub;
+    }
+
     /// Number of equality constraints.
     /**
      * This method will return \f$ n_{ec} \f$, the number of equality constraints of the problem.

--- a/include/pagmo/problems/golomb_ruler.hpp
+++ b/include/pagmo/problems/golomb_ruler.hpp
@@ -142,8 +142,8 @@ public:
         // 3 - We compute how many duplicate distances are there.
         std::sort(distances.begin(), distances.end(), detail::less_than_f<double>);
         f[1] = static_cast<double>(distances.size())
-               - std::distance(distances.begin(),
-                               std::unique(distances.begin(), distances.end(), detail::equal_to_f<double>));
+               - static_cast<double>(std::distance(
+                     distances.begin(), std::unique(distances.begin(), distances.end(), detail::equal_to_f<double>)));
         return f;
     }
     /// Box-bounds

--- a/include/pagmo/problems/unconstrain.hpp
+++ b/include/pagmo/problems/unconstrain.hpp
@@ -100,7 +100,8 @@ public:
      * @throws unspecified any exception thrown by the pagmo::problem constructor
      */
     template <typename T, ctor_enabler<T> = 0>
-    explicit unconstrain(T &&p, const std::string &method = "death penalty", const vector_double &weights = {})
+    explicit unconstrain(T &&p, const std::string &method = "death penalty",
+                         const vector_double &weights = vector_double())
         : m_problem(std::forward<T>(p)), m_weights(weights)
     {
         // The number of constraints in the original udp

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -162,8 +162,14 @@ inline double uniform_integral_from_range_impl(double lb, double ub, Rng &r_engi
     // result to double precision.
     // NOTE: the use of numeric_cast ensures that the conversion to long long is checked
     // (in case of overflow, an exception will be thrown).
-    const auto l = boost::numeric_cast<long long>(lb);
-    const auto u = boost::numeric_cast<long long>(ub);
+    long long l, u;
+    try {
+        l = boost::numeric_cast<long long>(lb);
+        u = boost::numeric_cast<long long>(ub);
+    } catch (...) {
+        pagmo_throw(std::invalid_argument, "Cannot generate a random integer if the lower/upper bounds are not within "
+                                           "the bounds of the long long type");
+    }
     // NOTE: it should be safe here to do a raw cast, as the result
     // will be within the original bounds and thus representable by double.
     return static_cast<double>(std::uniform_int_distribution<long long>(l, u)(r_engine));
@@ -209,8 +215,8 @@ inline double uniform_integral_from_range_impl(double lb, double ub, Rng &r_engi
  * @throws std::invalid_argument if:
  * - the bounds are not finite,
  * - \f$ lb > ub \f$,
- * - \f$ lb \f$ and/or \f$ ub \f$ are not integral values.
- * @throws unspecified any exception raised by <tt>boost::numeric_cast()</tt>.
+ * - \f$ lb \f$ and/or \f$ ub \f$ are not integral values,
+ * - \f$ lb \f$ and/or \f$ ub \f$ are not within the bounds of the ``long long`` type.
  *
  * @returns a random integral value
  */

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -29,23 +29,20 @@ see https://www.gnu.org/licenses/. */
 #ifndef PAGMO_UTILS_GENERIC_HPP
 #define PAGMO_UTILS_GENERIC_HPP
 
-/** \file generic.hpp
- * \brief Utilities of general interest
- *
- * This header contains utilities useful in general for PaGMO purposes
- */
-
+#include <cassert>
 #include <cmath>
 #include <limits>
 #include <numeric>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <pagmo/detail/custom_comparisons.hpp>
 #include <pagmo/exceptions.hpp>
 #include <pagmo/problem.hpp>
-#include <pagmo/rng.hpp>
 #include <pagmo/types.hpp>
 
 namespace pagmo
@@ -53,13 +50,13 @@ namespace pagmo
 
 namespace detail
 {
-/// Checks that all elements of the problem bounds are not equal
+
+// Checks that all elements of the problem bounds are not equal
 inline bool some_bound_is_equal(const problem &prob)
 {
     // Some variable renaming
-    const auto bounds = prob.get_bounds();
-    const auto &lb = bounds.first;
-    const auto &ub = bounds.second;
+    const auto &lb = prob.get_lb();
+    const auto &ub = prob.get_ub();
     // Since the bounds are extracted from problem we can be sure they have equal length
     for (decltype(lb.size()) i = 0u; i < lb.size(); ++i) {
         if (lb[i] == ub[i]) {
@@ -68,158 +65,243 @@ inline bool some_bound_is_equal(const problem &prob)
     }
     return false;
 }
-}
 
-/// Generates a random number within some lower and upper bounds
-/**
- * Creates a random number within a closed range. If
- * both the lower and upper bounds are finite numbers, then the generated value
- * \f$ x \f$ will be such that \f$lb \le x < ub\f$. If \f$lb == ub\f$ then \f$lb\f$ is
- * returned.
- *
- * \verbatim embed:rst:leading-asterisk
- * .. note::
- *
- *    This helper function has to be preferred to ``std::uniform_real<double>(r_engine)`` as it
- *    also performs additional checks avoiding undefined behaviour in pagmo.
- *
- * \endverbatim
- *
- * Example:
- *
- * @code{.unparsed}
- * std::mt19937 r_engine(32u);
- * auto x = uniform_real_from_range(3,5,r_engine); // a random value
- * auto x = uniform_real_from_range(2,2,r_engine); // the value 2.
- * @endcode
- *
- * @param lb lower bound
- * @param ub upper bound
- * @param r_engine a <tt>std::mt19937</tt> random engine
- *
- * @throws std::invalid_argument if:
- * - the bounds contain NaNs or infs,
- *   or \f$ lb > ub \f$,
- * - if \f$ub-lb\f$ is larger than implementation-defined value
- *
- * @returns a random floating-point value
- */
-inline double uniform_real_from_range(double lb, double ub, detail::random_engine_type &r_engine)
+// Check that the lower/upper bounds lb/ub are suitable for the
+// generation of a real number. The boolean flags specify at
+// compile time which checks to run.
+template <bool FiniteCheck, bool LbUbCheck, bool RangeCheck>
+inline void uniform_real_from_range_checks(double lb, double ub)
 {
     // NOTE: see here for the requirements for floating-point RNGS:
     // http://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution/uniform_real_distribution
 
     // 0 - Forbid random generation when bounds are not finite.
-    if (!std::isfinite(lb) || !std::isfinite(ub)) {
-        pagmo_throw(std::invalid_argument, "Cannot generate a random point if the bounds are not finite");
+    if (FiniteCheck) {
+        if (!std::isfinite(lb) || !std::isfinite(ub)) {
+            pagmo_throw(std::invalid_argument, "Cannot generate a random real if the bounds are not finite");
+        }
+    } else {
+        assert(std::isfinite(lb) && std::isfinite(ub));
     }
+
     // 1 - Check that lb is <= ub
-    if (lb > ub) {
-        pagmo_throw(std::invalid_argument,
-                    "Lower bound is greater than upper bound. Cannot generate a random point in [lb, ub]");
+    if (LbUbCheck) {
+        if (lb > ub) {
+            pagmo_throw(std::invalid_argument,
+                        "Cannot generate a random real if the lower bound is larger than the upper bound");
+        }
+    } else {
+        assert(lb <= ub);
     }
+
     // 2 - Bounds cannot be too large
-    const auto delta = ub - lb;
-    if (!std::isfinite(delta) || delta > std::numeric_limits<double>::max()) {
-        pagmo_throw(std::invalid_argument, "Cannot generate a random point within bounds that are too large");
+    if (RangeCheck) {
+        const auto delta = ub - lb;
+        if (!std::isfinite(delta) || delta > std::numeric_limits<double>::max()) {
+            pagmo_throw(std::invalid_argument, "Cannot generate a random real within bounds that are too large");
+        }
+    } else {
+        assert(std::isfinite(ub - lb) && (ub - lb) <= std::numeric_limits<double>::max());
     }
-    // 3 - If the bounds are equal we don't call the RNG, as that would be undefined behaviour.
-    if (lb == ub) {
-        return lb;
-    }
-    return std::uniform_real_distribution<double>(lb, ub)(r_engine);
 }
 
-/// Generates a random decision vector
+// Implementation of the uniform_real_from_range() function.
+template <bool FiniteCheck, bool LbUbCheck, bool RangeCheck, typename Rng>
+inline double uniform_real_from_range_impl(double lb, double ub, Rng &r_engine)
+{
+    // Run the checks on the bounds.
+    uniform_real_from_range_checks<FiniteCheck, LbUbCheck, RangeCheck>(lb, ub);
+    // If the bounds are equal we don't call the RNG, as that would be undefined behaviour.
+    return (lb == ub) ? lb : std::uniform_real_distribution<double>(lb, ub)(r_engine);
+}
+
+// Check that the lower/upper bounds lb/ub are suitable for the
+// generation of an integral number. The boolean flags specify at
+// compile time which checks to run.
+template <bool FiniteCheck, bool LbUbCheck, bool IntCheck>
+inline void uniform_integral_from_range_checks(double lb, double ub)
+{
+    // 0 - Check for finite bounds.
+    if (FiniteCheck) {
+        if (!std::isfinite(lb) || !std::isfinite(ub)) {
+            pagmo_throw(std::invalid_argument, "Cannot generate a random integer if the bounds are not finite");
+        }
+    } else {
+        assert(std::isfinite(lb) && std::isfinite(ub));
+    }
+
+    // 1 - Check that lb is <= ub
+    if (LbUbCheck) {
+        if (lb > ub) {
+            pagmo_throw(std::invalid_argument,
+                        "Cannot generate a random integer if the lower bound is larger than the upper bound");
+        }
+    } else {
+        assert(lb <= ub);
+    }
+
+    // 2 - Check that lb/ub are integral values.
+    if (IntCheck) {
+        if (std::trunc(lb) != lb || std::trunc(ub) != ub) {
+            pagmo_throw(std::invalid_argument,
+                        "Cannot generate a random integer if the lower/upper bounds are not integral values");
+        }
+    } else {
+        assert(std::trunc(lb) == lb && std::trunc(ub) == ub);
+    }
+}
+
+// Implementation of the uniform_integral_from_range() function.
+template <bool FiniteCheck, bool LbUbCheck, bool IntCheck, typename Rng>
+inline double uniform_integral_from_range_impl(double lb, double ub, Rng &r_engine)
+{
+    // Run the checks on the bounds.
+    uniform_integral_from_range_checks<FiniteCheck, LbUbCheck, IntCheck>(lb, ub);
+    // We will convert ub/lb to the widest signed integral type possible (long long),
+    // do the generation using uniform_int_distribution, and finally convert back the
+    // result to double precision.
+    // NOTE: the use of numeric_cast ensures that the conversion to long long is checked
+    // (in case of overflow, an exception will be thrown).
+    const auto l = boost::numeric_cast<long long>(lb);
+    const auto u = boost::numeric_cast<long long>(ub);
+    // NOTE: it should be safe here to do a raw cast, as the result
+    // will be within the original bounds and thus representable by double.
+    return static_cast<double>(std::uniform_int_distribution<long long>(l, u)(r_engine));
+}
+
+} // namespace detail
+
+/// Generate a random integral number within some lower and upper bounds
 /**
- * Creates a random decision vector within some bounds. If
- * both the lower and upper bounds are finite numbers, then the \f$i\f$-th
- * component of the randomly generated pagmo::vector_double will be such that
- * \f$lb_i \le x_i < ub_i\f$. If \f$lb_i == ub_i\f$ then \f$lb_i\f$ is
- * returned. If an integer part is specified then the corresponding components
- * are guaranteed to be integers.
+ * This function will create a random integral number within a closed range. If
+ * both the lower and upper bounds are finite numbers, then the generated value
+ * \f$ x \f$ will be such that \f$lb \le x \le ub\f$.
  *
  * Example:
  *
  * @code{.unparsed}
  * std::mt19937 r_engine(32u);
- * auto x = random_decision_vector({{1,3},{3,5}}, r_engine); // a random vector
- * auto x = random_decision_vector({{1,3},{1,3}}, r_engine); // the vector {1,3}
- * auto x = random_decision_vector({{1,3},{1,5}}, r_engine, 1); // the vector {1,3} or {1,4} or {1,5}
+ * auto x = uniform_integral_from_range(3,5,r_engine); // one of [3, 4, 5].
+ * auto x = uniform_integral_from_range(2,2,r_engine); // the value 2.
  * @endcode
  *
- * @param bounds an <tt>std::pair</tt> containing the bounds
- * @param r_engine a <tt>std::mt19937</tt> random engine
- * @param nix size of the integer part
+ * \verbatim embed:rst:leading-asterisk
+ * .. note::
+ *
+ *    The return value is created internally via an integral random number
+ *    generator based on the ``long long`` type, and then cast back to ``double``.
+ *    Thus, if the absolute values of the lower/upper bounds are large enough, any of
+ *    the following may happen:
+ *
+ *    * the conversion of the lower/upper bounds to ``long long`` may produce an overflow error,
+ *    * the conversion of the randomly-generated ``long long`` integer back to ``double`` may yield an
+ *      inexact result.
+ *
+ *    In pratice, on modern mainstream computer architectures, this function will produce uniformly-distributed
+ *    integral values as long as the absolute values of the bounds do not exceed :math:`2^{53}`.
+ *
+ * \endverbatim
+ *
+ * @param lb lower bound
+ * @param ub upper bound
+ * @param r_engine a C++ random engine
  *
  * @throws std::invalid_argument if:
- * - the bounds are not of equal length, they have zero size, they contain NaNs or infs,
- *   \f$ \mathbf{ub} < \mathbf {lb}\f$, the integer part is larger than the bounds size or
- *   the bounds of the integer part are not integers.
- * - if \f$ub_i-lb_i\f$ is larger than implementation-defined value
+ * - the bounds are not finite,
+ * - \f$ lb > ub \f$,
+ * - \f$ lb \f$ and/or \f$ ub \f$ are not integral values.
+ * @throws unspecified any exception raised by <tt>boost::numeric_cast()</tt>.
+ *
+ * @returns a random integral value
+ */
+template <typename Rng>
+inline double uniform_integral_from_range(double lb, double ub, Rng &r_engine)
+{
+    // Activate all checks on lb/ub.
+    return detail::uniform_integral_from_range_impl<true, true, true>(lb, ub, r_engine);
+}
+
+/// Generate a random real number within some lower and upper bounds
+/**
+ * This function will create a random real number within a half-open range. If
+ * both the lower and upper bounds are finite numbers, then the generated value
+ * \f$ x \f$ will be such that \f$lb \le x < ub\f$. If \f$lb = ub\f$, then \f$lb\f$ is
+ * returned.
+ *
+ * Example:
+ *
+ * @code{.unparsed}
+ * std::mt19937 r_engine(32u);
+ * auto x = uniform_real_from_range(3,5,r_engine); // a random real in the [3, 5) range.
+ * auto x = uniform_real_from_range(2,2,r_engine); // the value 2.
+ * @endcode
+ *
+ * @param lb lower bound
+ * @param ub upper bound
+ * @param r_engine a C++ random engine
+ *
+ * @throws std::invalid_argument if:
+ * - the bounds are not finite,
+ * - \f$ lb > ub \f$,
+ * - \f$ ub - lb \f$ is larger than an implementation-defined value.
+ *
+ * @returns a random floating-point value
+ */
+template <typename Rng>
+inline double uniform_real_from_range(double lb, double ub, Rng &r_engine)
+{
+    // Activate all checks on lb/ub.
+    return detail::uniform_real_from_range_impl<true, true, true>(lb, ub, r_engine);
+}
+
+/// Generate a random decision vector compatible with a problem
+/**
+ * This function will generate a decision vector whose values
+ * are randomly chosen with uniform probability within
+ * the input problem's bounds.
+ *
+ * For the continuous part of the decision vector, the values will be
+ * generated via pagmo::uniform_real_from_range().
+ *
+ * For the discrete part of the decision vector, the values will be generated
+ * via pagmo::uniform_integral_from_range().
+ *
+ * @param prob the input pagmo::problem
+ * @param r_engine a C++ random engine
+ *
+ * @throws unspecified any exception thrown by pagmo::uniform_real_from_range() or pagmo::uniform_integral_from_range().
  *
  * @returns a pagmo::vector_double containing a random decision vector
  */
-inline vector_double random_decision_vector(const std::pair<vector_double, vector_double> &bounds,
-                                            detail::random_engine_type &r_engine, vector_double::size_type nix = 0u)
+template <typename Rng>
+inline vector_double random_decision_vector(const problem &prob, Rng &r_engine)
 {
-    // This will check for consistent vector lengths, non-null sizes, lb <= ub, no NaNs and consistency in
-    // the integer part
-    detail::check_problem_bounds(bounds, nix);
-    auto nx = bounds.first.size();
-    vector_double retval(nx);
-    auto ncx = nx - nix;
+    // Prepare the return value.
+    vector_double out(prob.get_nx());
 
-    for (decltype(ncx) i = 0u; i < ncx; ++i) {
-        retval[i] = uniform_real_from_range(bounds.first[i], bounds.second[i], r_engine);
+    // Fetch a few quantities from prob.
+    const auto nx = prob.get_nx();
+    const auto nix = prob.get_nix();
+    const auto ncx = nx - nix;
+    const auto &lb = prob.get_lb();
+    const auto &ub = prob.get_ub();
+
+    // Continuous part.
+    for (vector_double::size_type i = 0u; i < ncx; ++i) {
+        // NOTE: the lb<=ub check is not needed, as it is ensured by the problem class.
+        // Still need to check for finiteness and range.
+        out[i] = detail::uniform_real_from_range_impl<true, false, true>(lb[i], ub[i], r_engine);
     }
+
+    // Integer part.
     for (auto i = ncx; i < nx; ++i) {
-        // To ensure a uniform int distribution from a uniform float distribution we floor the result
-        // adding 1 tot he upper bound so that e.g.
-        // [0,1] -> draw a float from [0,2] and floor it (that is 0. or 1. with 50%)
-        // [3,3] -> draw a float from [3,4] and floor it (that is always 3.)
-        double lb = bounds.first[i], ub = bounds.second[i];
-        auto tmp = uniform_real_from_range(lb, ub + 1, r_engine);
-        retval[i] = std::floor(tmp);
+        // NOTE: the lb<=ub check and the check that lb/ub are integral values are not needed,
+        // as they are ensured by the problem class.
+        // Still need to check for finiteness.
+        out[i] = detail::uniform_integral_from_range_impl<true, false, false>(lb[i], ub[i], r_engine);
     }
-    return retval;
-}
 
-/// Generates a random decision vector
-/**
- * Creates a random decision vector within some bounds. If
- * both the lower and upper bounds are finite numbers, then the \f$i\f$-th
- * component of the randomly generated pagmo::vector_double will be such that
- * \f$lb_i \le x_i < ub_i\f$. If \f$lb_i == ub_i\f$ then \f$lb_i\f$ is
- * returned. If an integer part is specified then the corresponding components
- * are guaranteed to be integers.
- *
- * Example:
- *
- * @code{.unparsed}
- * std::mt19937 r_engine(32u);
- * auto x = random_decision_vector({1,3},{3,5}, r_engine); // a random vector
- * auto x = random_decision_vector({1,3},{1,3}, r_engine); // the vector {1,3}
- * auto x = random_decision_vector({{1,3},{1,5}}, r_engine, 1); // the vector {1,3} or {1,4} or {1,5}
- * @endcode
- *
- * @param lb a vector_double containing the lower bounds
- * @param ub a vector_double containing the upper bounds
- * @param r_engine a <tt>std::mt19937</tt> random engine
- * @param nix size of the integer part
- *
- * @throws std::invalid_argument if:
- * - the bounds are not of equal length, they have zero size, they contain NaNs or infs,
- *   \f$ \mathbf{ub} < \mathbf {lb}\f$, the integer part is larger than the bounds size or
- *   the bounds of the integer part are not integers.
- * - if \f$ub_i-lb_i\f$ is larger than implementation-defined value
- *
- * @returns a pagmo::vector_double containing a random decision vector
- */
-inline vector_double random_decision_vector(const vector_double &lb, const vector_double &ub,
-                                            detail::random_engine_type &r_engine, vector_double::size_type nix = 0u)
-{
-    return random_decision_vector({lb, ub}, r_engine, nix);
+    return out;
 }
 
 /// Binomial coefficient

--- a/include/pagmo/utils/generic.hpp
+++ b/include/pagmo/utils/generic.hpp
@@ -385,8 +385,8 @@ inline std::vector<std::vector<vector_double::size_type>> kNN(const std::vector<
 namespace detail
 {
 // modifies a chromosome so that it will be in the bounds. elements that are off are resampled at random in the bounds
-inline void force_bounds_random(vector_double &x, const vector_double &lb, const vector_double &ub,
-                                detail::random_engine_type &r_engine)
+template <typename Rng>
+inline void force_bounds_random(vector_double &x, const vector_double &lb, const vector_double &ub, Rng &r_engine)
 {
     assert(x.size() == lb.size());
     assert(x.size() == ub.size());

--- a/pygmo/_problem_test.py
+++ b/pygmo/_problem_test.py
@@ -73,7 +73,7 @@ class problem_test_case(_ut.TestCase):
 
     def run_basic_tests(self):
         # Tests for minimal problem, and mandatory methods.
-        from numpy import all, array
+        from numpy import all, array, ndarray, dtype
         from .core import problem, rosenbrock, null_problem
         # Def construction.
         p = problem()
@@ -141,6 +141,14 @@ class problem_test_case(_ut.TestCase):
         self.assert_(isinstance(prob.get_bounds(), tuple))
         self.assert_(all(prob.get_bounds()[0] == [0, 0]))
         self.assert_(all(prob.get_bounds()[1] == [1, 1]))
+        self.assertTrue(all(prob.get_lb() == [0, 0]))
+        self.assertTrue(all(prob.get_ub() == [1, 1]))
+        self.assertTrue(isinstance(prob.get_lb(), ndarray))
+        self.assertTrue(isinstance(prob.get_ub(), ndarray))
+        self.assertTrue(prob.get_lb().dtype == dtype('float64'))
+        self.assertTrue(prob.get_ub().dtype == dtype('float64'))
+        self.assertTrue(prob.get_lb().shape == (2,))
+        self.assertTrue(prob.get_ub().shape == (2,))
         self.assertEqual(prob.get_nx(), 2)
         self.assertEqual(prob.get_nf(), 1)
         self.assertEqual(prob.get_nec(), 0)

--- a/pygmo/core.cpp
+++ b/pygmo/core.cpp
@@ -774,14 +774,13 @@ BOOST_PYTHON_MODULE(core)
     bp::def("ideal", lcast([](const bp::object &p) { return pygmo::v_to_a(pagmo::ideal(pygmo::to_vvd(p))); }),
             pygmo::ideal_docstring().c_str(), bp::arg("points"));
     // Generic utilities
-    bp::def("random_decision_vector",
-            lcast([](const bp::object &lb, const bp::object &ub, vector_double::size_type nix) -> bp::object {
+    bp::def("random_decision_vector", lcast([](const pagmo::problem &p) -> bp::object {
                 using reng_t = pagmo::detail::random_engine_type;
                 reng_t tmp_rng(static_cast<reng_t::result_type>(pagmo::random_device::next()));
-                auto retval = random_decision_vector(pygmo::to_vd(lb), pygmo::to_vd(ub), tmp_rng, nix);
+                auto retval = random_decision_vector(p, tmp_rng);
                 return pygmo::v_to_a(retval);
             }),
-            pygmo::random_decision_vector_docstring().c_str(), (bp::arg("lb"), bp::arg("ub"), bp::arg("nix") = 0u));
+            pygmo::random_decision_vector_docstring().c_str(), (bp::arg("prob")));
 
     // Gradient and Hessians utilities
     bp::def("estimate_sparsity", lcast([](const bp::object &func, const bp::object &x, double dx) -> bp::object {

--- a/pygmo/core.cpp
+++ b/pygmo/core.cpp
@@ -526,6 +526,10 @@ BOOST_PYTHON_MODULE(core)
                  return bp::make_tuple(pygmo::v_to_a(retval.first), pygmo::v_to_a(retval.second));
              }),
              pygmo::problem_get_bounds_docstring().c_str())
+        .def("get_lb", lcast([](const pagmo::problem &p) { return pygmo::v_to_a(p.get_lb()); }),
+             pygmo::problem_get_lb_docstring().c_str())
+        .def("get_ub", lcast([](const pagmo::problem &p) { return pygmo::v_to_a(p.get_ub()); }),
+             pygmo::problem_get_ub_docstring().c_str())
         .def("gradient", lcast([](const pagmo::problem &p, const bp::object &dv) {
                  return pygmo::v_to_a(p.gradient(pygmo::to_vd(dv)));
              }),

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -88,8 +88,7 @@ Returns:
     :class:`numpy.ndarray`: a random decision vector within the problem’s bounds
 
 Raises:
-    unspecified: any exception thrown by :func:`pygmo.problem.fitness()` or by failures at the intersection between C++ and
-      Python (e.g., type conversion errors, mismatched function signatures, etc.)
+    unspecified: any exception thrown by :func:`pygmo.random_decision_vector()`
 
 )";
 }
@@ -2950,27 +2949,29 @@ See also the docs of the relevant C++ method :cpp:func:`pagmo::simulated_anneali
 
 std::string random_decision_vector_docstring()
 {
-    return R"(random_decision_vector_docstring(lb, ub, nix = 0)
+    return R"(random_decision_vector(prob)
 
-Creates a random decision vector within some bounds using pygmo's global rng. If
-both the lower and upper bounds are finite numbers, then the :math:`i`-th
-component of the randomly generated pagmo::vector_double will be such that
-:math:`lb_i \le x_i < ub_i`. If :math:`lb_i == ub_i` then :math:`lb_i` is
-returned. If an integer part *nix* is specified then the last *nix* components
-are guaranteed to be integers within the specified (integer) bounds.
+This function will generate a decision vector whose values are randomly chosen with uniform probability within
+the lower and upper bounds :math:`lb` and :math:`ub` of the input :class:`~pygmo.problem` *prob*.
+
+For the continuous part of the decision vector, the :math:`i`-th component of the randomly generated decision
+vector will be such that :math:`lb_i \le x_i < ub_i`.
+
+For the discrete part of the decision vector, the :math:`i`-th component of the randomly generated decision vector
+is guaranteed to be an integral value such that :math:`lb_i \le x_i \le ub_i`.
+
+For both the continuous and discrete parts of the decision vector, if :math:`lb_i == ub_i` then :math:`lb_i` is returned.
 
 Args:
-    lb (array-like object): the lower bounds
-    ub (array-like object): the upper bounds
-    nix (``int``): the integer size
-
-Raises:
-    ValueError: if *nix* is negative or greater than an implementation-defined value
-    ValueError: if *lb* and *ub* are malformed (unequal lenght, zero size, *nix* larger than ``len(lb)`` or bounds are not integers in their last *nix* components)
-    TypeError: if *lb* or *ub* cannot be converted to a vector of floats
+    prob (:class:`~pygmo.problem`): the input problem
 
 Returns:
-    1D NumPy float array: the random decision vector
+    :class:`numpy.ndarray`: a random decision vector within the problem’s bounds
+
+Raises:
+    ValueError: if the problem's bounds are not finite or larger than an implementation-defined limit
+    OverflowError: if the problem's discrete bounds exceed the range of the ``long long`` C++ type
+
 )";
 }
 
@@ -3649,7 +3650,10 @@ std::string set_global_rng_seed_docstring()
 In pygmo it is, in general, possible to control the seed of all random generators by a dedicated *seed* kwarg passed on via various
 constructors. If no *seed* is passed pygmo randomly creates a seed for you using its global random number generator. 
 
-This function allows to be able to reset the seed of auch a global random number generator. This can be useful to create a deterministic behaviour of pygmo easily. 
+This function allows to be able to reset the seed of such a global random number generator. This can be useful to create a deterministic behaviour of pygmo easily. 
+
+Args:
+    seed (int): the new global seed for random number generation
 
 .. note::
    In complex parallel evolutions obtaining a deterministic behaviour is not possible even setting the global seed as

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -487,8 +487,8 @@ std::string problem_get_bounds_docstring()
 
 Box-bounds.
 
-This method will invoke the ``get_bounds()`` method of the UDP to return the box-bounds
-:math:`(\mathbf{lb}, \mathbf{ub})` of the problem. Infinities in the bounds are allowed.
+This method will return the box-bounds :math:`(\mathbf{lb}, \mathbf{ub})` of the problem,
+as returned by the ``get_bounds()`` method of the UDP. Infinities in the bounds are allowed.
 
 The ``get_bounds()`` method of the UDP must return the box-bounds as a tuple of 2 elements,
 the lower bounds vector and the upper bounds vector, which must be represented as iterable Python objects (e.g.,
@@ -497,6 +497,44 @@ of a :class:`~pygmo.problem`.
 
 Returns:
     ``tuple``: a tuple of two 1D NumPy float arrays representing the lower and upper box-bounds of the problem
+
+Raises:
+    unspecified: any exception thrown by the invoked method of the underlying C++ class, or failures at the
+      intersection between C++ and Python (e.g., type conversion errors, mismatched function signatures, etc.)
+
+)";
+}
+
+std::string problem_get_lb_docstring()
+{
+    return R"(get_lb()
+
+Lower box-bounds.
+
+This method will return the lower box-bounds for this problem. See :func:`~pygmo.problem.get_bounds()`
+for a detailed explanation of how the bounds are determined.
+
+Returns:
+    1D NumPy float array: an array representing the lower box-bounds of this problem
+
+Raises:
+    unspecified: any exception thrown by the invoked method of the underlying C++ class, or failures at the
+      intersection between C++ and Python (e.g., type conversion errors, mismatched function signatures, etc.)
+
+)";
+}
+
+std::string problem_get_ub_docstring()
+{
+    return R"(get_ub()
+
+Upper box-bounds.
+
+This method will return the upper box-bounds for this problem. See :func:`~pygmo.problem.get_bounds()`
+for a detailed explanation of how the bounds are determined.
+
+Returns:
+    1D NumPy float array: an array representing the upper box-bounds of this problem
 
 Raises:
     unspecified: any exception thrown by the invoked method of the underlying C++ class, or failures at the

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -102,7 +102,7 @@ Index of the best individual.
 If the problem is single-objective and unconstrained, the best is simply the individual with the smallest fitness. If the problem
 is, instead, single objective, but with constraints, the best will be defined using the criteria specified in :func:`pygmo.sort_population_con()`.
 If the problem is multi-objective one single best is not well defined. In this case the user can still obtain a strict ordering of the population
-individuals by calling the :func:`pygmo.sort_population_ mo()` function.
+individuals by calling the :func:`pygmo.sort_population_mo()` function.
 
 Args:
     tol (``float`` or array-like object): scalar tolerance or vector of tolerances to be applied to each constraints. By default, the c_tol attribute 
@@ -127,7 +127,7 @@ Index of the worst individual.
 If the problem is single-objective and unconstrained, the worst is simply the individual with the largest fitness. If the problem
 is, instead, single objective, but with constraints, the worst will be defined using the criteria specified in :func:`pygmo.sort_population_con()`.
 If the problem is multi-objective one single worst is not well defined. In this case the user can still obtain a strict ordering of the population
-individuals by calling the :func:`pygmo.sort_population_ mo()` function.
+individuals by calling the :func:`pygmo.sort_population_mo()` function.
 
 Args:
     tol (``float`` or array-like object): scalar tolerance or vector of tolerances to be applied to each constraints

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -2970,7 +2970,6 @@ Returns:
 
 Raises:
     ValueError: if the problem's bounds are not finite or larger than an implementation-defined limit
-    OverflowError: if the problem's discrete bounds exceed the range of the ``long long`` C++ type
 
 )";
 }

--- a/pygmo/docstrings.hpp
+++ b/pygmo/docstrings.hpp
@@ -54,6 +54,8 @@ std::string problem_docstring();
 std::string problem_get_best_docstring(const std::string &);
 std::string problem_fitness_docstring();
 std::string problem_get_bounds_docstring();
+std::string problem_get_lb_docstring();
+std::string problem_get_ub_docstring();
 std::string problem_get_nec_docstring();
 std::string problem_get_nic_docstring();
 std::string problem_get_nobj_docstring();

--- a/pygmo/test.py
+++ b/pygmo/test.py
@@ -1073,11 +1073,11 @@ class random_decision_vector_test_case(_ut.TestCase):
         self.assertRaises(
             ValueError, lambda: random_decision_vector(problem(prob([0, -nan], [1, nan]))))
         self.assertRaises(
-            OverflowError, lambda: random_decision_vector(problem(prob([0, 0], [1, 1E100], 1))))
+            ValueError, lambda: random_decision_vector(problem(prob([0, 0], [1, 1E100], 1))))
         self.assertRaises(
-            OverflowError, lambda: random_decision_vector(problem(prob([0, -1E100], [1, 0], 1))))
+            ValueError, lambda: random_decision_vector(problem(prob([0, -1E100], [1, 0], 1))))
         self.assertRaises(
-            OverflowError, lambda: random_decision_vector(problem(prob([0, -1E100], [1, 1E100], 1))))
+            ValueError, lambda: random_decision_vector(problem(prob([0, -1E100], [1, 1E100], 1))))
 
 
 class luksan_vlcek1_test_case(_ut.TestCase):

--- a/tests/cec2006.cpp
+++ b/tests/cec2006.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(cec2006_fitness_test)
     // We check that all problems return a fitness
     for (unsigned i = 1u; i <= 24u; ++i) {
         cec2006 udp{i};
-        auto x = random_decision_vector(statics::m_bounds[i - 1u], r_engine); // a random vector
+        auto x = random_decision_vector(problem(udp), r_engine); // a random vector
         auto f = udp.fitness(x);
         BOOST_CHECK_EQUAL(f.size(), statics::m_nec[i - 1u] + statics::m_nic[i - 1u] + 1);
         BOOST_CHECK((udp.get_name().find("CEC2006 - g")) != std::string::npos);

--- a/tests/cec2009.cpp
+++ b/tests/cec2009.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(cec2009_fitness_test)
     // We check that all problems return a fitness of the correct dims
     for (unsigned i = 1u; i <= 10u; ++i) {
         cec2009 udp{i, false};
-        auto x = random_decision_vector(udp.get_bounds(), r_engine); // a random vector
+        auto x = random_decision_vector(problem(udp), r_engine); // a random vector
         auto f = udp.fitness(x);
         BOOST_CHECK_EQUAL(f.size(), udp.get_nobj());
         BOOST_CHECK((udp.get_name().find("CEC2009 - UF")) != std::string::npos);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(cec2009_fitness_test)
     // We check that all problems return a fitness of the correct dims
     for (unsigned i = 1u; i <= 10u; ++i) {
         cec2009 udp{i, true};
-        auto x = random_decision_vector(udp.get_bounds(), r_engine); // a random vector
+        auto x = random_decision_vector(problem(udp), r_engine); // a random vector
         auto f = udp.fitness(x);
         BOOST_CHECK_EQUAL(f.size(), statics::m_nic[i - 1u] + udp.get_nobj());
         BOOST_CHECK((udp.get_name().find("CEC2009 - CF")) != std::string::npos);

--- a/tests/cec2013.cpp
+++ b/tests/cec2013.cpp
@@ -50,8 +50,7 @@ BOOST_AUTO_TEST_CASE(cec2013_test)
     for (unsigned int i = 1u; i <= 28u; ++i) {
         for (auto dim : allowed_dims) {
             cec2013 udp{i, dim};
-            auto x = random_decision_vector({vector_double(dim, -100.), vector_double(dim, 100.)},
-                                            r_engine); // a random vector
+            auto x = random_decision_vector(problem(udp), r_engine); // a random vector
             BOOST_CHECK_NO_THROW(udp.fitness(x));
         }
         BOOST_CHECK((cec2013{i, 2u}.get_name().find("CEC2013 - f")) != std::string::npos);

--- a/tests/cec2014.cpp
+++ b/tests/cec2014.cpp
@@ -56,8 +56,7 @@ BOOST_AUTO_TEST_CASE(cec2014_test)
                 continue;
             }
             cec2014 udp{i, dim};
-            auto x = random_decision_vector({vector_double(dim, -100.), vector_double(dim, 100.)},
-                                            r_engine); // a random vector
+            auto x = random_decision_vector(problem(udp), r_engine); // a random vector
             BOOST_CHECK_NO_THROW(udp.fitness(x));
         }
         BOOST_CHECK((cec2014{i, 10u}.get_name().find("CEC2014 - f")) != std::string::npos);

--- a/tests/cmaes.cpp
+++ b/tests/cmaes.cpp
@@ -27,12 +27,15 @@ GNU Lesser General Public License along with the PaGMO library.  If not,
 see https://www.gnu.org/licenses/. */
 
 #define BOOST_TEST_MODULE cmaes_test
-#include <boost/lexical_cast.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-#include <boost/test/included/unit_test.hpp>
+
+#include <initializer_list>
 #include <iostream>
 #include <limits> //  std::numeric_limits<double>::infinity();
 #include <string>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <pagmo/algorithm.hpp>
 #include <pagmo/algorithms/cmaes.hpp>
@@ -190,8 +193,8 @@ BOOST_AUTO_TEST_CASE(cmaes_evolve_test)
     population pop_lb{problem{unbounded_lb{}}};
     population pop_ub{problem{unbounded_ub{}}};
     for (auto i = 0u; i < 20u; ++i) {
-        pop_lb.push_back(pagmo::random_decision_vector({0.}, {1.}, r_engine));
-        pop_ub.push_back(pagmo::random_decision_vector({0.}, {1.}, r_engine));
+        pop_lb.push_back(vector_double{pagmo::uniform_real_from_range(0., 1., r_engine)});
+        pop_ub.push_back(vector_double{pagmo::uniform_real_from_range(0., 1., r_engine)});
     }
     BOOST_CHECK_THROW(cmaes{10u}.evolve(pop_lb), std::invalid_argument);
     BOOST_CHECK_THROW(cmaes{10u}.evolve(pop_ub), std::invalid_argument);

--- a/tests/generic.cpp
+++ b/tests/generic.cpp
@@ -214,6 +214,10 @@ BOOST_AUTO_TEST_CASE(random_decision_vector_test)
     BOOST_CHECK((random_decision_vector(problem{udp00{{0, 0}, {1, 1}}}, r_engine)[1] < 1.));
     BOOST_CHECK((random_decision_vector(problem{udp00{{0, 0}, {1, 0}}}, r_engine)[1] == 0.));
     for (auto i = 0; i < 100; ++i) {
+        const auto tmp = random_decision_vector(problem{udp00{{0}, {2}, 1}}, r_engine)[0];
+        BOOST_CHECK(tmp == 0. || tmp == 1. || tmp == 2.);
+    }
+    for (auto i = 0; i < 100; ++i) {
         const auto res = random_decision_vector(problem{udp00{{0, -20}, {1, 20}, 1}}, r_engine);
         BOOST_CHECK(std::trunc(res[1]) == res[1]);
     }

--- a/tests/generic.cpp
+++ b/tests/generic.cpp
@@ -29,16 +29,45 @@ see https://www.gnu.org/licenses/. */
 #define BOOST_TEST_MODULE generic_utilities_test
 #include <boost/test/included/unit_test.hpp>
 
+#include <cmath>
+#include <initializer_list>
 #include <limits>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
+
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <pagmo/io.hpp>
+#include <pagmo/problem.hpp>
 #include <pagmo/rng.hpp>
 #include <pagmo/types.hpp>
 #include <pagmo/utils/generic.hpp>
 
 using namespace pagmo;
+
+// A UDP with user-defined bounds.
+struct udp00 {
+    udp00() = default;
+    explicit udp00(vector_double lb, vector_double ub, vector_double::size_type nix = 0)
+        : m_lb(lb), m_ub(ub), m_nix(nix)
+    {
+    }
+    vector_double fitness(const vector_double &) const
+    {
+        return {0};
+    }
+    std::pair<vector_double, vector_double> get_bounds() const
+    {
+        return {m_lb, m_ub};
+    }
+    vector_double::size_type get_nix() const
+    {
+        return m_nix;
+    }
+    vector_double m_lb, m_ub;
+    vector_double::size_type m_nix;
+};
 
 BOOST_AUTO_TEST_CASE(uniform_real_from_range_test)
 {
@@ -56,51 +85,117 @@ BOOST_AUTO_TEST_CASE(uniform_real_from_range_test)
     BOOST_CHECK_THROW(uniform_real_from_range(-nan, 3, r_engine), std::invalid_argument);
     BOOST_CHECK_THROW(uniform_real_from_range(-3, nan, r_engine), std::invalid_argument);
     BOOST_CHECK_THROW(uniform_real_from_range(inf, inf, r_engine), std::invalid_argument);
+
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(1, 0, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(
+                ia.what(), "Cannot generate a random integer if the lower bound is larger than the upper bound");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(0, inf, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(-inf, 0, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(-inf, inf, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(0, nan, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(-nan, 0, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(-nan, nan, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(ia.what(), "Cannot generate a random integer if the bounds are not finite");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(0, .1, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(
+                ia.what(), "Cannot generate a random integer if the lower/upper bounds are not integral values");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(0.1, 2, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(
+                ia.what(), "Cannot generate a random integer if the lower/upper bounds are not integral values");
+        });
+    BOOST_CHECK_EXCEPTION(
+        uniform_integral_from_range(0.1, 0.2, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+            return boost::contains(
+                ia.what(), "Cannot generate a random integer if the lower/upper bounds are not integral values");
+        });
+    if (big > static_cast<double>(std::numeric_limits<long long>::max())
+        && -big < static_cast<double>(std::numeric_limits<long long>::min())) {
+        BOOST_CHECK_THROW(uniform_integral_from_range(0, big, r_engine), boost::numeric::positive_overflow);
+        BOOST_CHECK_THROW(uniform_integral_from_range(-big, 0, r_engine), boost::numeric::negative_overflow);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(random_decision_vector_test)
 {
     auto inf = std::numeric_limits<double>::infinity();
     auto big = std::numeric_limits<double>::max();
-    auto nan = std::numeric_limits<double>::quiet_NaN();
     detail::random_engine_type r_engine(pagmo::random_device::next());
 
     // Test the throws
-    BOOST_CHECK_THROW(random_decision_vector({{1, 2}, {0, 3}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{1, -big}, {2, big}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{1, -inf}, {2, 32}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{1, 2, 3}, {2, 3}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, 2, 3}, {1, 4, nan}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, 2, nan}, {1, 4, 4}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, nan, 3}, {1, nan, 4}}, r_engine), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, 2, 3}, {1, 4, 5}}, r_engine, 4u), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, 2, 3.1}, {1, 4, 5}}, r_engine, 1u), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, 2, 3}, {1, 4, 5.2}}, r_engine, 1u), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, -1.1, 3}, {1, 2, 5}}, r_engine, 2u), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, -1.1, big}, {1, 2, big}}, r_engine, 2u), std::invalid_argument);
-    BOOST_CHECK_NO_THROW(random_decision_vector({{0, -1.1, big}, {1, 2, big}}, r_engine));
-    BOOST_CHECK_THROW(random_decision_vector({{0, -1.1, -inf}, {1, 2, inf}}, r_engine, 2u), std::invalid_argument);
-    BOOST_CHECK_THROW(random_decision_vector({{0, -1.1, inf}, {1, 2, inf}}, r_engine, 2u), std::invalid_argument);
-
-    // Test the results
-    BOOST_CHECK((random_decision_vector({{3, 4}, {3, 4}}, r_engine) == vector_double{3, 4}));
-    BOOST_CHECK(random_decision_vector({{0, 0}, {1, 1}}, r_engine)[0] >= 0);
-    BOOST_CHECK(random_decision_vector({{0, 0}, {1, 1}}, r_engine)[1] < 1);
-    BOOST_CHECK(random_decision_vector({{0, 0}, {1, 0}}, r_engine, 1u)[1] == 0);
-    for (auto i = 0u; i < 100; ++i) {
-        auto res = random_decision_vector({{0, -20}, {1, 20}}, r_engine, 1u);
-        BOOST_CHECK(res[1] == std::floor(res[1]));
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0}, {inf}}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random real if the bounds are not finite");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{-inf}, {0}}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random real if the bounds are not finite");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{-inf}, {inf}}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random real if the bounds are not finite");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{-big}, {big}}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random real within bounds that are too large");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0, 0}, {1, inf}, 1}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random integer if the bounds are not finite");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0, -inf}, {1, 0}, 1}}, r_engine), std::invalid_argument,
+                          [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random integer if the bounds are not finite");
+                          });
+    BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0, -inf}, {1, inf}, 1}}, r_engine),
+                          std::invalid_argument, [](const std::invalid_argument &ia) {
+                              return boost::contains(ia.what(),
+                                                     "Cannot generate a random integer if the bounds are not finite");
+                          });
+    if (big > static_cast<double>(std::numeric_limits<long long>::max())
+        && -big < static_cast<double>(std::numeric_limits<long long>::min())) {
+        BOOST_CHECK_THROW(random_decision_vector(problem{udp00{{0, 0}, {1, big}, 1}}, r_engine),
+                          boost::numeric::positive_overflow);
+        BOOST_CHECK_THROW(random_decision_vector(problem{udp00{{0, -big}, {1, 0}, 1}}, r_engine),
+                          boost::numeric::negative_overflow);
     }
 
-    // Test the overload
-    BOOST_CHECK((random_decision_vector({3, 4}, {3, 4}, r_engine) == vector_double{3, 4}));
-    BOOST_CHECK(random_decision_vector({0, 0}, {1, 1}, r_engine)[0] >= 0);
-    BOOST_CHECK(random_decision_vector({0, 0}, {1, 1}, r_engine)[1] < 1);
-    BOOST_CHECK(random_decision_vector({0, 0}, {1, 0}, r_engine, 1u)[1] == 0);
-
-    for (auto i = 0u; i < 100; ++i) {
-        auto res = random_decision_vector({0, -20}, {1, 20}, r_engine, 1u);
-        BOOST_CHECK(res[1] == std::floor(res[1]));
+    // Test the results
+    BOOST_CHECK((random_decision_vector(problem{udp00{{3, 4}, {3, 4}}}, r_engine) == vector_double{3, 4}));
+    BOOST_CHECK((random_decision_vector(problem{udp00{{3, 4}, {3, 4}, 1}}, r_engine) == vector_double{3, 4}));
+    BOOST_CHECK((random_decision_vector(problem{udp00{{0, 0}, {1, 1}}}, r_engine)[0] >= 0.));
+    BOOST_CHECK((random_decision_vector(problem{udp00{{0, 0}, {1, 1}}}, r_engine)[1] < 1.));
+    BOOST_CHECK((random_decision_vector(problem{udp00{{0, 0}, {1, 0}}}, r_engine)[1] == 0.));
+    for (auto i = 0; i < 100; ++i) {
+        const auto res = random_decision_vector(problem{udp00{{0, -20}, {1, 20}, 1}}, r_engine);
+        BOOST_CHECK(std::trunc(res[1]) == res[1]);
     }
 }
 

--- a/tests/generic.cpp
+++ b/tests/generic.cpp
@@ -132,8 +132,18 @@ BOOST_AUTO_TEST_CASE(uniform_real_from_range_test)
         });
     if (big > static_cast<double>(std::numeric_limits<long long>::max())
         && -big < static_cast<double>(std::numeric_limits<long long>::min())) {
-        BOOST_CHECK_THROW(uniform_integral_from_range(0, big, r_engine), boost::numeric::positive_overflow);
-        BOOST_CHECK_THROW(uniform_integral_from_range(-big, 0, r_engine), boost::numeric::negative_overflow);
+        BOOST_CHECK_EXCEPTION(
+            uniform_integral_from_range(0, big, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+                return boost::contains(ia.what(),
+                                       "Cannot generate a random integer if the lower/upper bounds are not within "
+                                       "the bounds of the long long type");
+            });
+        BOOST_CHECK_EXCEPTION(
+            uniform_integral_from_range(-big, 0, r_engine), std::invalid_argument, [](const std::invalid_argument &ia) {
+                return boost::contains(ia.what(),
+                                       "Cannot generate a random integer if the lower/upper bounds are not within "
+                                       "the bounds of the long long type");
+            });
     }
 }
 
@@ -181,10 +191,20 @@ BOOST_AUTO_TEST_CASE(random_decision_vector_test)
                           });
     if (big > static_cast<double>(std::numeric_limits<long long>::max())
         && -big < static_cast<double>(std::numeric_limits<long long>::min())) {
-        BOOST_CHECK_THROW(random_decision_vector(problem{udp00{{0, 0}, {1, big}, 1}}, r_engine),
-                          boost::numeric::positive_overflow);
-        BOOST_CHECK_THROW(random_decision_vector(problem{udp00{{0, -big}, {1, 0}, 1}}, r_engine),
-                          boost::numeric::negative_overflow);
+        BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0, 0}, {1, big}, 1}}, r_engine),
+                              std::invalid_argument, [](const std::invalid_argument &ia) {
+                                  return boost::contains(
+                                      ia.what(),
+                                      "Cannot generate a random integer if the lower/upper bounds are not within "
+                                      "the bounds of the long long type");
+                              });
+        BOOST_CHECK_EXCEPTION(random_decision_vector(problem{udp00{{0, -big}, {1, 0}, 1}}, r_engine),
+                              std::invalid_argument, [](const std::invalid_argument &ia) {
+                                  return boost::contains(
+                                      ia.what(),
+                                      "Cannot generate a random integer if the lower/upper bounds are not within "
+                                      "the bounds of the long long type");
+                              });
     }
 
     // Test the results

--- a/tests/minlp_rastrigin.cpp
+++ b/tests/minlp_rastrigin.cpp
@@ -56,15 +56,15 @@ BOOST_AUTO_TEST_CASE(min_lp_rastrigin_test)
     // Fitness test
     detail::random_engine_type r_engine(pagmo::random_device::next());
     for (auto i = 0u; i < 100; ++i) {
-        auto x = random_decision_vector({-5.12, -10}, {5.12, -5}, r_engine, 0u);
+        auto x = random_decision_vector(problem(minlp_rastrigin{2u, 0u}), r_engine);
         BOOST_CHECK((minlp_rastrigin{2u, 0u}.fitness(x)) == rastrigin{2u}.fitness(x));
         BOOST_CHECK((minlp_rastrigin{2u, 0u}.gradient(x)) == rastrigin{2u}.gradient(x));
         BOOST_CHECK((minlp_rastrigin{2u, 0u}.hessians(x)) == rastrigin{2u}.hessians(x));
-        x = random_decision_vector({-5.12, -10}, {5.12, -5}, r_engine, 1u);
+        x = random_decision_vector(problem(minlp_rastrigin{1u, 1u}), r_engine);
         BOOST_CHECK((minlp_rastrigin{1u, 1u}.fitness(x)) == rastrigin{2u}.fitness(x));
         BOOST_CHECK((minlp_rastrigin{1u, 1u}.gradient(x)) == rastrigin{2u}.gradient(x));
         // BOOST_CHECK((minlp_rastrigin{1u, 1u}.hessians(x)) == rastrigin{2u}.hessians(x));
-        x = random_decision_vector({-5, -10}, {-4, -5}, r_engine, 2u);
+        x = random_decision_vector(problem(minlp_rastrigin{0u, 2u}), r_engine);
         BOOST_CHECK((minlp_rastrigin{0u, 2u}.fitness(x)) == rastrigin{2u}.fitness(x));
         BOOST_CHECK((minlp_rastrigin{0u, 2u}.gradient(x)) == rastrigin{2u}.gradient(x));
         BOOST_CHECK((minlp_rastrigin{0u, 2u}.hessians(x)) == rastrigin{2u}.hessians(x));

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -692,6 +692,8 @@ BOOST_AUTO_TEST_CASE(problem_getters_test)
     BOOST_CHECK((p1.get_c_tol() == vector_double{0., 0., 0., 0., 0., 0., 0.}));
     BOOST_CHECK(p1.get_nf() == 2 + 3 + 4);
     BOOST_CHECK((p1.get_bounds() == std::pair<vector_double, vector_double>{{13, 13}, {17, 17}}));
+    BOOST_CHECK((p1.get_lb() == vector_double{13, 13}));
+    BOOST_CHECK((p1.get_ub() == vector_double{17, 17}));
 
     // Making some evaluations
     auto N = 1235u;

--- a/tests/xnes.cpp
+++ b/tests/xnes.cpp
@@ -27,12 +27,15 @@ GNU Lesser General Public License along with the PaGMO library.  If not,
 see https://www.gnu.org/licenses/. */
 
 #define BOOST_TEST_MODULE cmaes_test
-#include <boost/lexical_cast.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-#include <boost/test/included/unit_test.hpp>
+
+#include <initializer_list>
 #include <iostream>
 #include <limits> //  std::numeric_limits<double>::infinity();
 #include <string>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <pagmo/algorithm.hpp>
 #include <pagmo/algorithms/xnes.hpp>
@@ -195,8 +198,8 @@ BOOST_AUTO_TEST_CASE(xnes_evolve_test)
     population pop_lb{problem{unbounded_lb{}}};
     population pop_ub{problem{unbounded_ub{}}};
     for (auto i = 0u; i < 20u; ++i) {
-        pop_lb.push_back(pagmo::random_decision_vector({0.}, {1.}, r_engine));
-        pop_ub.push_back(pagmo::random_decision_vector({0.}, {1.}, r_engine));
+        pop_lb.push_back(vector_double{pagmo::uniform_real_from_range(0., 1., r_engine)});
+        pop_ub.push_back(vector_double{pagmo::uniform_real_from_range(0., 1., r_engine)});
     }
     BOOST_CHECK_THROW(xnes{10u}.evolve(pop_lb), std::invalid_argument);
     BOOST_CHECK_THROW(xnes{10u}.evolve(pop_ub), std::invalid_argument);


### PR DESCRIPTION
This PR mainly reworks the ``random_decision_vector()`` function to take in input a problem, rather than bounds, integer dimensions, etc. This simplifies the API and avoids needlessly repeating various sanity checks.

I also added a couple of getters in problem to fetch directly references to the lower/upper bounds (rather than having to create a copy of them each time ``get_bounds()`` is called) and fixed a bunch of smaller test/doc issues.