### PR TITLE
Fix building without Eigen support

### DIFF
--- a/include/pagmo/pagmo.hpp
+++ b/include/pagmo/pagmo.hpp
@@ -58,7 +58,9 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/algorithms/sea.hpp>
 #include <pagmo/algorithms/sga.hpp>
 #include <pagmo/algorithms/simulated_annealing.hpp>
+#if defined(PAGMO_WITH_EIGEN3)
 #include <pagmo/algorithms/xnes.hpp>
+#endif
 #include <pagmo/archipelago.hpp>
 #include <pagmo/exceptions.hpp>
 #include <pagmo/io.hpp>


### PR DESCRIPTION
`xnes.hpp` should be included only when Eigen support is enabled. Otherwise, the compiler complains by [this line](https://github.com/esa/pagmo2/blob/master/include/pagmo/algorithms/xnes.hpp#L588).

Related issue: https://github.com/dartsim/dart/issues/1310