### PR TITLE
C++ improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(PAGMO_BUILD_PAGMO)
         "${CMAKE_CURRENT_SOURCE_DIR}/src/rng.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/threading.cpp"
         # UDP.
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/null_problem.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/cec2006.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/cec2009.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/schwefel.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ if(PAGMO_BUILD_PAGMO)
         "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/minlp_rastrigin.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/problems/luksan_vlcek1.cpp"
         # UDA.
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/null_algorithm.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/de.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/pso.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/not_population_based.cpp"

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -7,7 +7,13 @@ Changelog
 New
 ~~~
 
-- Implement an ``uninstall`` target in the build system (`#282 <https://github.com/esa/pagmo2/pull/282>`__).
+- Various additions to the C++ API of user-defined classes
+  (`#294 <https://github.com/esa/pagmo2/pull/294>`__).
+
+- Ipopt is now included in the linux pip packages (`#293 <https://github.com/esa/pagmo2/pull/293>`__).
+
+- Implement an ``uninstall`` target in the build system when using the CMake
+  ``Unix Makefiles`` generator (`#282 <https://github.com/esa/pagmo2/pull/282>`__).
 
 - Implement the Grey Wolf Optimizer algorithm (`#268 <https://github.com/esa/pagmo2/pull/268>`__).
 
@@ -20,13 +26,18 @@ New
 Changes
 ~~~~~~~
 
+- Various improvements to the MinGW pip packages: the toolchain
+  and the dependencies have
+  been updated, support for Python 3.7 has been added (`#292 <https://github.com/esa/pagmo2/pull/292>`__).
+
 - **BREAKING**: unconditionally disable the CEC2013/CEC2014 problem suites on
-  OSX, as they cause build
-  issues when compiling pygmo (`#266 <https://github.com/esa/pagmo2/pull/266>`__).
+  OSX and MinGW, as they cause build
+  issues (`#266 <https://github.com/esa/pagmo2/pull/266>`__, `#292 <https://github.com/esa/pagmo2/pull/292>`__).
 
 - Various performance improvements in the :cpp:class:`~pagmo::population` API (`#250 <https://github.com/esa/pagmo2/pull/250>`__).
 
-- **BREAKING**: :class:`pygmo.problem` and :class:`pygmo.algorithm` cannot be used as UDPs and UDAs any more.
+- **BREAKING**: :class:`pygmo.problem` and :class:`pygmo.algorithm`
+  cannot be used as UDPs and UDAs any more.
   This change makes the behaviour of pygmo consistent with the behaviour of pagmo (`#248 <https://github.com/esa/pagmo2/pull/248>`__).
 
 Fix
@@ -44,7 +55,8 @@ Fix
   `#245 <https://github.com/esa/pagmo2/pull/245>`__, `#248 <https://github.com/esa/pagmo2/pull/248>`__,
   `#257 <https://github.com/esa/pagmo2/pull/257>`__, `#262 <https://github.com/esa/pagmo2/pull/262>`__,
   `#265 <https://github.com/esa/pagmo2/pull/265>`__, `#266 <https://github.com/esa/pagmo2/pull/266>`__,
-  `#279 <https://github.com/esa/pagmo2/pull/279>`__).
+  `#279 <https://github.com/esa/pagmo2/pull/279>`__, `#287 <https://github.com/esa/pagmo2/pull/287>`__,
+  `#288 <https://github.com/esa/pagmo2/pull/288>`__).
 
 - The :cpp:class:`~pagmo::fork_island` UDI now properly cleans up zombie processes (`#242 <https://github.com/esa/pagmo2/pull/242>`__).
 

--- a/doc/sphinx/docs/cpp/bfe.rst
+++ b/doc/sphinx/docs/cpp/bfe.rst
@@ -63,7 +63,7 @@ Batch fitness evaluator
    .. warning::
 
       The only operations allowed on a moved-from :cpp:class:`pagmo::bfe` are destruction,
-      assignment, and the invocation of the :cpp:func:`~pagmo::bfe::has_value()` member function.
+      assignment, and the invocation of the :cpp:func:`~pagmo::bfe::is_valid()` member function.
       Any other operation will result in undefined behaviour.
 
    .. cpp:function:: bfe()
@@ -210,11 +210,11 @@ Batch fitness evaluator
 
       :return: the thread safety level of the UDBFE.
 
-   .. cpp:function:: bool has_value() const
+   .. cpp:function:: bool is_valid() const
 
-      Check if this bfe contains a UDBFE.
+      Check if this bfe is in a valid state.
 
-      :return: ``true`` if *this* contains a UDBFE, ``false`` otherwise (i.e., if *this* was moved from).
+      :return: ``false`` if *this* was moved from, ``true`` otherwise.
 
    .. cpp:function:: template <typename Archive> void save(Archive &ar, unsigned) const
    .. cpp:function:: template <typename Archive> void load(Archive &ar, unsigned)

--- a/doc/sphinx/docs/cpp/bfe.rst
+++ b/doc/sphinx/docs/cpp/bfe.rst
@@ -62,8 +62,9 @@ Batch fitness evaluator
 
    .. warning::
 
-      A moved-from :cpp:class:`~pagmo::bfe` is destructible and assignable. Any other operation will result
-      in undefined behaviour.
+      The only operations allowed on a moved-from :cpp:class:`pagmo::bfe` are destruction,
+      assignment, and the invocation of the :cpp:func:`~pagmo::bfe::has_value()` member function.
+      Any other operation will result in undefined behaviour.
 
    .. cpp:function:: bfe()
 
@@ -103,6 +104,29 @@ Batch fitness evaluator
       :param x: the input UDBFE.
 
       :exception unspecified: any exception thrown by the public API of the UDBFE, or by memory allocation failures.
+
+   .. cpp:function:: template <typename T> bfe &operator=(T &&x)
+
+      Generic assignment operator from a UDBFE.
+
+      This operator participates in overload resolution only if ``T``, after the removal of reference
+      and cv qualifiers, is not :cpp:class:`~pagmo::bfe` and if it satisfies :cpp:class:`pagmo::is_udbfe`.
+
+      Additionally, the operator will also be enabled if ``T``, after the removal of reference and cv qualifiers,
+      is a function type with the following signature
+
+      .. code-block:: c++
+
+         vector_double (const problem &, const vector_double &)
+
+      This operator will set the internal UDBFE to *x* by constructing a :cpp:class:`~pagmo::bfe` from *x*,
+      and then move-assigning the result to *this*.
+
+      :param x: the input UDBFE.
+
+      :return: a reference to *this*.
+
+      :exception unspecified: any exception thrown by the generic constructor from a UDBFE.
 
    .. cpp:function:: template <typename T> const T *extract() const noexcept
    .. cpp:function:: template <typename T> T *extract() noexcept
@@ -185,6 +209,12 @@ Batch fitness evaluator
       That is, pagmo assumes by default that is it safe to operate concurrently on distinct UDBFE instances.
 
       :return: the thread safety level of the UDBFE.
+
+   .. cpp:function:: bool has_value() const
+
+      Check if this bfe contains a UDBFE.
+
+      :return: ``true`` if *this* contains a UDBFE, ``false`` otherwise (i.e., if *this* was moved from).
 
    .. cpp:function:: template <typename Archive> void save(Archive &ar, unsigned) const
    .. cpp:function:: template <typename Archive> void load(Archive &ar, unsigned)

--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -398,8 +398,9 @@ namespace pagmo
  * \verbatim embed:rst:leading-asterisk
  * .. note::
  *
- *    A moved-from pagmo::algorithm is destructible and assignable. Any other operation will result
- *    in undefined behaviour.
+ *    The only operations allowed on a moved-from :cpp:class:`pagmo::algorithm` are destruction,
+ *    assignment, and the invocation of the :cpp:func:`~pagmo::algorithm::has_value()` member function.
+ *    Any other operation will result in undefined behaviour.
  *
  * \endverbatim
  */
@@ -453,6 +454,32 @@ public:
     algorithm &operator=(algorithm &&) noexcept;
     // Copy assignment.
     algorithm &operator=(const algorithm &);
+    /// Assignment from a user-defined algorithm of type \p T
+    /**
+     * \verbatim embed:rst:leading-asterisk
+     * .. note::
+     *
+     *    This operator is not enabled if, after the removal of cv and reference qualifiers,
+     *    ``T`` is of type :cpp:class:`pagmo::algorithm` (that is, this operator does not compete with the copy/move
+     *    assignment operators of :cpp:class:`pagmo::algorithm`), or if ``T`` does not satisfy
+     *    :cpp:class:`pagmo::is_uda`.
+     *
+     * \endverbatim
+     *
+     * This operator will set the internal UDA to ``x`` by constructing a pagmo::algorithm from ``x``, and then
+     * move-assigning the result to ``this``.
+     *
+     * @param x the UDA.
+     *
+     * @return a reference to ``this``.
+     *
+     * @throws unspecified any exception thrown by the constructor from UDA.
+     */
+    template <typename T, generic_ctor_enabler<T> = 0>
+    algorithm &operator=(T &&x)
+    {
+        return (*this) = algorithm(std::forward<T>(x));
+    }
 
     /// Extract a const pointer to the UDA.
     /**
@@ -606,6 +633,9 @@ public:
     {
         return m_thread_safety;
     }
+
+    // Check if the algorithm contains a UDA.
+    bool has_value() const;
 
     /// Save to archive.
     /**

--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -399,7 +399,7 @@ namespace pagmo
  * .. note::
  *
  *    The only operations allowed on a moved-from :cpp:class:`pagmo::algorithm` are destruction,
- *    assignment, and the invocation of the :cpp:func:`~pagmo::algorithm::has_value()` member function.
+ *    assignment, and the invocation of the :cpp:func:`~pagmo::algorithm::is_valid()` member function.
  *    Any other operation will result in undefined behaviour.
  *
  * \endverbatim
@@ -634,8 +634,8 @@ public:
         return m_thread_safety;
     }
 
-    // Check if the algorithm contains a UDA.
-    bool has_value() const;
+    // Check if the algorithm is valid.
+    bool is_valid() const;
 
     /// Save to archive.
     /**

--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -58,31 +58,6 @@ see https://www.gnu.org/licenses/. */
 namespace pagmo
 {
 
-/// Null algorithm
-/**
- * This algorithm is used to implement the default constructors of pagmo::algorithm and of the meta-algorithms.
- */
-struct PAGMO_DLL_PUBLIC null_algorithm {
-    // Evolve method.
-    population evolve(const population &) const;
-    /// Algorithm name.
-    /**
-     * @return <tt>"Null algorithm"</tt>.
-     */
-    std::string get_name() const
-    {
-        return "Null algorithm";
-    }
-    // Serialization support.
-    template <typename Archive>
-    void serialize(Archive &, unsigned);
-};
-
-} // namespace pagmo
-
-namespace pagmo
-{
-
 /// Detect \p set_verbosity() method.
 /**
  * This type trait will be \p true if \p T provides a method with
@@ -693,7 +668,5 @@ private:
 PAGMO_DLL_PUBLIC std::ostream &operator<<(std::ostream &, const algorithm &);
 
 } // namespace pagmo
-
-PAGMO_S11N_ALGORITHM_EXPORT_KEY(pagmo::null_algorithm)
 
 #endif

--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -276,12 +276,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS algo_inner final : algo_inner_base {
         pagmo_throw(not_implemented_error,
                     "The set_seed() method has been invoked but it is not implemented in the UDA");
     }
-    template <typename U, enable_if_t<pagmo::has_set_seed<U>::value && override_has_set_seed<U>::value, int> = 0>
+    template <typename U,
+              enable_if_t<detail::conjunction<pagmo::has_set_seed<U>, override_has_set_seed<U>>::value, int> = 0>
     static bool has_set_seed_impl(const U &a)
     {
         return a.has_set_seed();
     }
-    template <typename U, enable_if_t<pagmo::has_set_seed<U>::value && !override_has_set_seed<U>::value, int> = 0>
+    template <
+        typename U,
+        enable_if_t<detail::conjunction<pagmo::has_set_seed<U>, detail::negation<override_has_set_seed<U>>>::value,
+                    int> = 0>
     static bool has_set_seed_impl(const U &)
     {
         return true;
@@ -302,14 +306,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS algo_inner final : algo_inner_base {
         pagmo_throw(not_implemented_error,
                     "The set_verbosity() method has been invoked but it is not implemented in the UDA");
     }
-    template <typename U,
-              enable_if_t<pagmo::has_set_verbosity<U>::value && override_has_set_verbosity<U>::value, int> = 0>
+    template <
+        typename U,
+        enable_if_t<detail::conjunction<pagmo::has_set_verbosity<U>, override_has_set_verbosity<U>>::value, int> = 0>
     static bool has_set_verbosity_impl(const U &a)
     {
         return a.has_set_verbosity();
     }
-    template <typename U,
-              enable_if_t<pagmo::has_set_verbosity<U>::value && !override_has_set_verbosity<U>::value, int> = 0>
+    template <typename U, enable_if_t<detail::conjunction<pagmo::has_set_verbosity<U>,
+                                                          detail::negation<override_has_set_verbosity<U>>>::value,
+                                      int> = 0>
     static bool has_set_verbosity_impl(const U &)
     {
         return true;

--- a/include/pagmo/algorithms/null_algorithm.hpp
+++ b/include/pagmo/algorithms/null_algorithm.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2017-2018 PaGMO development team
+
+This file is part of the PaGMO library.
+
+The PaGMO library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+  * the GNU Lesser General Public License as published by the Free
+    Software Foundation; either version 3 of the License, or (at your
+    option) any later version.
+
+or
+
+  * the GNU General Public License as published by the Free Software
+    Foundation; either version 3 of the License, or (at your option) any
+    later version.
+
+or both in parallel, as here.
+
+The PaGMO library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the PaGMO library.  If not,
+see https://www.gnu.org/licenses/. */
+
+#ifndef PAGMO_ALGORITHMS_NULL_ALGORITHM_HPP
+#define PAGMO_ALGORITHMS_NULL_ALGORITHM_HPP
+
+#include <string>
+
+#include <pagmo/algorithm.hpp>
+#include <pagmo/detail/visibility.hpp>
+#include <pagmo/population.hpp>
+
+namespace pagmo
+{
+
+/// Null algorithm
+/**
+ * This algorithm is used to implement the default constructors of pagmo::algorithm and of the meta-algorithms.
+ */
+struct PAGMO_DLL_PUBLIC null_algorithm {
+    // Evolve method.
+    population evolve(const population &) const;
+    /// Algorithm name.
+    /**
+     * @return <tt>"Null algorithm"</tt>.
+     */
+    std::string get_name() const
+    {
+        return "Null algorithm";
+    }
+    // Serialization support.
+    template <typename Archive>
+    void serialize(Archive &, unsigned);
+};
+
+} // namespace pagmo
+
+PAGMO_S11N_ALGORITHM_EXPORT_KEY(pagmo::null_algorithm)
+
+#endif

--- a/include/pagmo/bfe.hpp
+++ b/include/pagmo/bfe.hpp
@@ -300,8 +300,8 @@ public:
         return m_thread_safety;
     }
 
-    // Check if the bfe contains a UDBFE.
-    bool has_value() const;
+    // Check if the bfe is valid.
+    bool is_valid() const;
 
     // Serialisation support.
     template <typename Archive>

--- a/include/pagmo/bfe.hpp
+++ b/include/pagmo/bfe.hpp
@@ -260,6 +260,13 @@ public:
     bfe &operator=(bfe &&) noexcept;
     // Copy assignment operator
     bfe &operator=(const bfe &);
+    // Assignment from a UDBFE.
+    template <typename T, generic_ctor_enabler<T> = 0>
+    bfe &operator=(T &&x)
+    {
+        return (*this) = bfe(std::forward<T>(x));
+    }
+
     // Extraction and related.
     template <typename T>
     const T *extract() const noexcept
@@ -292,6 +299,10 @@ public:
     {
         return m_thread_safety;
     }
+
+    // Check if the bfe contains a UDBFE.
+    bool has_value() const;
+
     // Serialisation support.
     template <typename Archive>
     void save(Archive &ar, unsigned) const

--- a/include/pagmo/detail/custom_comparisons.hpp
+++ b/include/pagmo/detail/custom_comparisons.hpp
@@ -38,6 +38,12 @@ see https://www.gnu.org/licenses/. */
 
 #include <pagmo/type_traits.hpp>
 
+// MINGW-specific warnings.
+#if defined(__GNUC__) && defined(__MINGW32__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#endif
+
 namespace pagmo
 {
 namespace detail
@@ -125,5 +131,9 @@ struct hash_vf {
 };
 } // namespace detail
 } // namespace pagmo
+
+#if defined(__GNUC__) && defined(__MINGW32__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/pagmo/island.hpp
+++ b/include/pagmo/island.hpp
@@ -409,8 +409,9 @@ PAGMO_DLL_PUBLIC std::ostream &operator<<(std::ostream &, evolve_status);
  * \verbatim embed:rst:leading-asterisk
  * .. warning::
  *
- *    A moved-from :cpp:class:`pagmo::island` is destructible and assignable. Any other operation will result
- *    in undefined behaviour.
+ *    The only operations allowed on a moved-from :cpp:class:`pagmo::island` are destruction,
+ *    assignment, and the invocation of the :cpp:func:`~pagmo::island::is_valid()` member function.
+ *    Any other operation will result in undefined behaviour.
  *
  * \endverbatim
  */
@@ -774,6 +775,8 @@ public:
     std::string get_name() const;
     // Island's extra info.
     std::string get_extra_info() const;
+    // Check if the island is valid.
+    bool is_valid() const;
     /// Save to archive.
     /**
      * This method will save \p this to the archive \p ar.

--- a/include/pagmo/pagmo.hpp
+++ b/include/pagmo/pagmo.hpp
@@ -73,6 +73,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/algorithms/moead.hpp>
 #include <pagmo/algorithms/not_population_based.hpp>
 #include <pagmo/algorithms/nsga2.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
 #include <pagmo/algorithms/pso.hpp>
 #include <pagmo/algorithms/pso_gen.hpp>
 #include <pagmo/algorithms/sade.hpp>
@@ -113,6 +114,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/lennard_jones.hpp>
 #include <pagmo/problems/luksan_vlcek1.hpp>
 #include <pagmo/problems/minlp_rastrigin.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rastrigin.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/schwefel.hpp>

--- a/include/pagmo/population.hpp
+++ b/include/pagmo/population.hpp
@@ -162,7 +162,8 @@ public:
      */
     template <
         typename T, typename U,
-        enable_if_t<std::is_constructible<problem, T &&>::value && std::is_constructible<bfe, U &&>::value, int> = 0>
+        enable_if_t<detail::conjunction<std::is_constructible<problem, T &&>, std::is_constructible<bfe, U &&>>::value,
+                    int> = 0>
     explicit population(T &&x, U &&b, size_type pop_size = 0u, unsigned seed = pagmo::random_device::next())
         : m_prob(std::forward<T>(x)), m_e(seed), m_seed(seed)
     {

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -73,81 +73,6 @@ see https://www.gnu.org/licenses/. */
 namespace pagmo
 {
 
-/// Null problem
-/**
- * This problem is used to implement the default constructors of pagmo::problem and of the meta-problems.
- */
-struct PAGMO_DLL_PUBLIC null_problem {
-    /// Constructor from number of objectives.
-    /**
-     * @param nobj the desired number of objectives.
-     * @param nec the desired number of equality constraints.
-     * @param nic the desired number of inequality constraints.
-     * @param nix the problem integer dimension.
-     *
-     * @throws std::invalid_argument if \p nobj is zero.
-     */
-    null_problem(vector_double::size_type nobj = 1u, vector_double::size_type nec = 0u,
-                 vector_double::size_type nic = 0u, vector_double::size_type nix = 0u);
-    // Fitness.
-    vector_double fitness(const vector_double &) const;
-    // Problem bounds.
-    std::pair<vector_double, vector_double> get_bounds() const;
-    /// Number of objectives.
-    /**
-     * @return the number of objectives of the problem (as specified upon construction).
-     */
-    vector_double::size_type get_nobj() const
-    {
-        return m_nobj;
-    }
-    /// Number of equality constraints.
-    /**
-     * @return the number of equality constraints of the problem (as specified upon construction).
-     */
-    vector_double::size_type get_nec() const
-    {
-        return m_nec;
-    }
-    /// Number of inequality constraints.
-    /**
-     * @return the number of inequality constraints of the problem (as specified upon construction).
-     */
-    vector_double::size_type get_nic() const
-    {
-        return m_nic;
-    }
-    /// Size of the integer part.
-    /**
-     * @return the size of the integer part (as specified upon construction).
-     */
-    vector_double::size_type get_nix() const
-    {
-        return m_nix;
-    }
-    /// Problem name.
-    /**
-     * @return <tt>"Null problem"</tt>.
-     */
-    std::string get_name() const
-    {
-        return "Null problem";
-    }
-    // Serialization
-    template <typename Archive>
-    void serialize(Archive &, unsigned);
-
-private:
-    vector_double::size_type m_nobj;
-    vector_double::size_type m_nec;
-    vector_double::size_type m_nic;
-    vector_double::size_type m_nix;
-};
-} // namespace pagmo
-
-namespace pagmo
-{
-
 /// Detect \p fitness() method.
 /**
  * This type trait will be \p true if \p T provides a method with
@@ -1765,7 +1690,5 @@ private:
 };
 
 } // namespace pagmo
-
-PAGMO_S11N_PROBLEM_EXPORT_KEY(pagmo::null_problem)
 
 #endif

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -1037,7 +1037,7 @@ PAGMO_DLL_PUBLIC vector_double prob_invoke_mem_batch_fitness(const problem &, co
  * .. warning::
  *
  *    The only operations allowed on a moved-from :cpp:class:`pagmo::problem` are destruction,
- *    assignment, and the invocation of the :cpp:func:`~pagmo::problem::has_value()` member function.
+ *    assignment, and the invocation of the :cpp:func:`~pagmo::problem::is_valid()` member function.
  *    Any other operation will result in undefined behaviour.
  *
  * \endverbatim
@@ -1586,8 +1586,8 @@ public:
         return m_thread_safety;
     }
 
-    // Check if the problem contains a UDP.
-    bool has_value() const;
+    // Check if the problem is in a valid state.
+    bool is_valid() const;
 
     /// Save to archive.
     /**

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -734,13 +734,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
                         + get_name_impl(value) + "'");
     }
     template <typename U,
-              enable_if_t<pagmo::has_batch_fitness<U>::value && pagmo::override_has_batch_fitness<U>::value, int> = 0>
+              enable_if_t<detail::conjunction<pagmo::has_batch_fitness<U>, pagmo::override_has_batch_fitness<U>>::value,
+                          int> = 0>
     static bool has_batch_fitness_impl(const U &p)
     {
         return p.has_batch_fitness();
     }
     template <typename U,
-              enable_if_t<pagmo::has_batch_fitness<U>::value && !pagmo::override_has_batch_fitness<U>::value, int> = 0>
+              enable_if_t<detail::conjunction<pagmo::has_batch_fitness<U>,
+                                              detail::negation<pagmo::override_has_batch_fitness<U>>>::value,
+                          int> = 0>
     static bool has_batch_fitness_impl(const U &)
     {
         return true;
@@ -772,13 +775,15 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
                     "The gradient has been requested, but it is not implemented in a UDP of type '"
                         + get_name_impl(value) + "'");
     }
-    template <typename U, enable_if_t<pagmo::has_gradient<U>::value && pagmo::override_has_gradient<U>::value, int> = 0>
+    template <typename U,
+              enable_if_t<detail::conjunction<pagmo::has_gradient<U>, pagmo::override_has_gradient<U>>::value, int> = 0>
     static bool has_gradient_impl(const U &p)
     {
         return p.has_gradient();
     }
-    template <typename U,
-              enable_if_t<pagmo::has_gradient<U>::value && !pagmo::override_has_gradient<U>::value, int> = 0>
+    template <typename U, enable_if_t<detail::conjunction<pagmo::has_gradient<U>,
+                                                          detail::negation<pagmo::override_has_gradient<U>>>::value,
+                                      int> = 0>
     static bool has_gradient_impl(const U &)
     {
         return true;
@@ -802,15 +807,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
         assert(false); // LCOV_EXCL_LINE
         throw;
     }
-    template <
-        typename U,
-        enable_if_t<pagmo::has_gradient_sparsity<U>::value && pagmo::override_has_gradient_sparsity<U>::value, int> = 0>
+    template <typename U, enable_if_t<detail::conjunction<pagmo::has_gradient_sparsity<U>,
+                                                          pagmo::override_has_gradient_sparsity<U>>::value,
+                                      int> = 0>
     static bool has_gradient_sparsity_impl(const U &p)
     {
         return p.has_gradient_sparsity();
     }
     template <typename U,
-              enable_if_t<pagmo::has_gradient_sparsity<U>::value && !pagmo::override_has_gradient_sparsity<U>::value,
+              enable_if_t<detail::conjunction<pagmo::has_gradient_sparsity<U>,
+                                              detail::negation<pagmo::override_has_gradient_sparsity<U>>>::value,
                           int> = 0>
     static bool has_gradient_sparsity_impl(const U &)
     {
@@ -833,13 +839,15 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
                     "The hessians have been requested, but they are not implemented in a UDP of type '"
                         + get_name_impl(value) + "'");
     }
-    template <typename U, enable_if_t<pagmo::has_hessians<U>::value && pagmo::override_has_hessians<U>::value, int> = 0>
+    template <typename U,
+              enable_if_t<detail::conjunction<pagmo::has_hessians<U>, pagmo::override_has_hessians<U>>::value, int> = 0>
     static bool has_hessians_impl(const U &p)
     {
         return p.has_hessians();
     }
-    template <typename U,
-              enable_if_t<pagmo::has_hessians<U>::value && !pagmo::override_has_hessians<U>::value, int> = 0>
+    template <typename U, enable_if_t<detail::conjunction<pagmo::has_hessians<U>,
+                                                          detail::negation<pagmo::override_has_hessians<U>>>::value,
+                                      int> = 0>
     static bool has_hessians_impl(const U &)
     {
         return true;
@@ -863,15 +871,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
         assert(false); // LCOV_EXCL_LINE
         throw;
     }
-    template <
-        typename U,
-        enable_if_t<pagmo::has_hessians_sparsity<U>::value && pagmo::override_has_hessians_sparsity<U>::value, int> = 0>
+    template <typename U, enable_if_t<detail::conjunction<pagmo::has_hessians_sparsity<U>,
+                                                          pagmo::override_has_hessians_sparsity<U>>::value,
+                                      int> = 0>
     static bool has_hessians_sparsity_impl(const U &p)
     {
         return p.has_hessians_sparsity();
     }
     template <typename U,
-              enable_if_t<pagmo::has_hessians_sparsity<U>::value && !pagmo::override_has_hessians_sparsity<U>::value,
+              enable_if_t<detail::conjunction<pagmo::has_hessians_sparsity<U>,
+                                              detail::negation<pagmo::override_has_hessians_sparsity<U>>>::value,
                           int> = 0>
     static bool has_hessians_sparsity_impl(const U &)
     {
@@ -912,7 +921,7 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
     {
         return 0u;
     }
-    template <typename U, typename std::enable_if<pagmo::has_set_seed<U>::value, int>::type = 0>
+    template <typename U, enable_if_t<pagmo::has_set_seed<U>::value, int> = 0>
     static void set_seed_impl(U &value, unsigned seed)
     {
         value.set_seed(seed);
@@ -924,12 +933,16 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS prob_inner final : prob_inner_base {
                     "The set_seed() method has been invoked, but it is not implemented in a UDP of type '"
                         + get_name_impl(value) + "'");
     }
-    template <typename U, enable_if_t<pagmo::has_set_seed<U>::value && override_has_set_seed<U>::value, int> = 0>
+    template <typename U,
+              enable_if_t<detail::conjunction<pagmo::has_set_seed<U>, override_has_set_seed<U>>::value, int> = 0>
     static bool has_set_seed_impl(const U &p)
     {
         return p.has_set_seed();
     }
-    template <typename U, enable_if_t<pagmo::has_set_seed<U>::value && !override_has_set_seed<U>::value, int> = 0>
+    template <
+        typename U,
+        enable_if_t<detail::conjunction<pagmo::has_set_seed<U>, detail::negation<override_has_set_seed<U>>>::value,
+                    int> = 0>
     static bool has_set_seed_impl(const U &)
     {
         return true;

--- a/include/pagmo/problems/null_problem.hpp
+++ b/include/pagmo/problems/null_problem.hpp
@@ -1,0 +1,117 @@
+/* Copyright 2017-2018 PaGMO development team
+
+This file is part of the PaGMO library.
+
+The PaGMO library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+  * the GNU Lesser General Public License as published by the Free
+    Software Foundation; either version 3 of the License, or (at your
+    option) any later version.
+
+or
+
+  * the GNU General Public License as published by the Free Software
+    Foundation; either version 3 of the License, or (at your option) any
+    later version.
+
+or both in parallel, as here.
+
+The PaGMO library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the PaGMO library.  If not,
+see https://www.gnu.org/licenses/. */
+
+#ifndef PAGMO_PROBLEMS_NULL_PROBLEM_HPP
+#define PAGMO_PROBLEMS_NULL_PROBLEM_HPP
+
+#include <string>
+#include <utility>
+
+#include <pagmo/detail/visibility.hpp>
+#include <pagmo/problem.hpp>
+#include <pagmo/types.hpp>
+
+namespace pagmo
+{
+
+/// Null problem
+/**
+ * This problem is used to implement the default constructors of pagmo::problem and of the meta-problems.
+ */
+struct PAGMO_DLL_PUBLIC null_problem {
+    /// Constructor from number of objectives.
+    /**
+     * @param nobj the desired number of objectives.
+     * @param nec the desired number of equality constraints.
+     * @param nic the desired number of inequality constraints.
+     * @param nix the problem integer dimension.
+     *
+     * @throws std::invalid_argument if \p nobj is zero.
+     */
+    null_problem(vector_double::size_type nobj = 1u, vector_double::size_type nec = 0u,
+                 vector_double::size_type nic = 0u, vector_double::size_type nix = 0u);
+    // Fitness.
+    vector_double fitness(const vector_double &) const;
+    // Problem bounds.
+    std::pair<vector_double, vector_double> get_bounds() const;
+    /// Number of objectives.
+    /**
+     * @return the number of objectives of the problem (as specified upon construction).
+     */
+    vector_double::size_type get_nobj() const
+    {
+        return m_nobj;
+    }
+    /// Number of equality constraints.
+    /**
+     * @return the number of equality constraints of the problem (as specified upon construction).
+     */
+    vector_double::size_type get_nec() const
+    {
+        return m_nec;
+    }
+    /// Number of inequality constraints.
+    /**
+     * @return the number of inequality constraints of the problem (as specified upon construction).
+     */
+    vector_double::size_type get_nic() const
+    {
+        return m_nic;
+    }
+    /// Size of the integer part.
+    /**
+     * @return the size of the integer part (as specified upon construction).
+     */
+    vector_double::size_type get_nix() const
+    {
+        return m_nix;
+    }
+    /// Problem name.
+    /**
+     * @return <tt>"Null problem"</tt>.
+     */
+    std::string get_name() const
+    {
+        return "Null problem";
+    }
+    // Serialization
+    template <typename Archive>
+    void serialize(Archive &, unsigned);
+
+private:
+    vector_double::size_type m_nobj;
+    vector_double::size_type m_nec;
+    vector_double::size_type m_nic;
+    vector_double::size_type m_nix;
+};
+
+} // namespace pagmo
+
+PAGMO_S11N_PROBLEM_EXPORT_KEY(pagmo::null_problem)
+
+#endif

--- a/pygmo/expose_algorithms_1.cpp
+++ b/pygmo/expose_algorithms_1.cpp
@@ -57,20 +57,21 @@ see https://www.gnu.org/licenses/. */
 
 #include <pagmo/config.hpp>
 
-#include <pagmo/algorithm.hpp>
-#if defined(PAGMO_WITH_NLOPT)
-#include <pagmo/algorithms/nlopt.hpp>
-#endif
 #include <pagmo/algorithms/gaco.hpp>
 #include <pagmo/algorithms/gwo.hpp>
 #include <pagmo/algorithms/ihs.hpp>
 #include <pagmo/algorithms/nsga2.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
 #include <pagmo/algorithms/pso.hpp>
 #include <pagmo/algorithms/pso_gen.hpp>
 #include <pagmo/algorithms/sade.hpp>
 #include <pagmo/algorithms/sea.hpp>
 #include <pagmo/algorithms/sga.hpp>
 #include <pagmo/algorithms/simulated_annealing.hpp>
+
+#if defined(PAGMO_WITH_NLOPT)
+#include <pagmo/algorithms/nlopt.hpp>
+#endif
 
 #include <pygmo/algorithm_exposition_suite.hpp>
 #include <pygmo/common_utils.hpp>

--- a/pygmo/expose_problems_0.cpp
+++ b/pygmo/expose_problems_0.cpp
@@ -61,17 +61,19 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/ackley.hpp>
 #include <pagmo/problems/cec2006.hpp>
 #include <pagmo/problems/cec2009.hpp>
-#if defined(PAGMO_ENABLE_CEC2014)
-#include <pagmo/problems/cec2014.hpp>
-#endif
 #include <pagmo/problems/decompose.hpp>
 #include <pagmo/problems/dtlz.hpp>
 #include <pagmo/problems/griewank.hpp>
 #include <pagmo/problems/hock_schittkowsky_71.hpp>
 #include <pagmo/problems/inventory.hpp>
 #include <pagmo/problems/lennard_jones.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/threading.hpp>
 #include <pagmo/types.hpp>
+
+#if defined(PAGMO_ENABLE_CEC2014)
+#include <pagmo/problems/cec2014.hpp>
+#endif
 
 #include <pygmo/common_utils.hpp>
 #include <pygmo/docstrings.hpp>

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -183,11 +183,11 @@ std::string algorithm::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
-/// Check if the algorithm contains a UDA.
+/// Check if the algorithm is in a valid state.
 /**
- * @return ``true`` if the algorithm contains a UDA, ``false`` otherwise (i.e., if ``this`` was moved from).
+ * @return ``false`` if ``this`` was moved from, ``true`` otherwise.
  */
-bool algorithm::has_value() const
+bool algorithm::is_valid() const
 {
     return static_cast<bool>(m_ptr);
 }

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -183,6 +183,15 @@ std::string algorithm::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
+/// Check if the algorithm contains a UDA.
+/**
+ * @return ``true`` if the algorithm contains a UDA, ``false`` otherwise (i.e., if ``this`` was moved from).
+ */
+bool algorithm::has_value() const
+{
+    return static_cast<bool>(m_ptr);
+}
+
 /// Streaming operator for pagmo::algorithm
 /**
  * This function will stream to \p os a human-readable representation of the input

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -31,35 +31,13 @@ see https://www.gnu.org/licenses/. */
 #include <utility>
 
 #include <pagmo/algorithm.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
 #include <pagmo/io.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/s11n.hpp>
 
 namespace pagmo
 {
-
-/// Evolve method.
-/**
- * In the null algorithm, the evolve method just returns the input
- * population.
- *
- * @param pop input population.
- *
- * @return a copy of the input population.
- */
-population null_algorithm::evolve(const population &pop) const
-{
-    return pop;
-}
-
-/// Serialization support.
-/**
- * This class is stateless, no data will be loaded or saved during serialization.
- */
-template <typename Archive>
-void null_algorithm::serialize(Archive &, unsigned)
-{
-}
 
 /// Default constructor.
 /**
@@ -234,5 +212,3 @@ std::ostream &operator<<(std::ostream &os, const algorithm &a)
 }
 
 } // namespace pagmo
-
-PAGMO_S11N_ALGORITHM_IMPLEMENT(pagmo::null_algorithm)

--- a/src/algorithms/null_algorithm.cpp
+++ b/src/algorithms/null_algorithm.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2017-2018 PaGMO development team
+
+This file is part of the PaGMO library.
+
+The PaGMO library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+  * the GNU Lesser General Public License as published by the Free
+    Software Foundation; either version 3 of the License, or (at your
+    option) any later version.
+
+or
+
+  * the GNU General Public License as published by the Free Software
+    Foundation; either version 3 of the License, or (at your option) any
+    later version.
+
+or both in parallel, as here.
+
+The PaGMO library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the PaGMO library.  If not,
+see https://www.gnu.org/licenses/. */
+
+#include <pagmo/algorithm.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
+#include <pagmo/population.hpp>
+#include <pagmo/s11n.hpp>
+
+namespace pagmo
+{
+
+/// Evolve method.
+/**
+ * In the null algorithm, the evolve method just returns the input
+ * population.
+ *
+ * @param pop input population.
+ *
+ * @return a copy of the input population.
+ */
+population null_algorithm::evolve(const population &pop) const
+{
+    return pop;
+}
+
+/// Serialization support.
+/**
+ * This class is stateless, no data will be loaded or saved during serialization.
+ */
+template <typename Archive>
+void null_algorithm::serialize(Archive &, unsigned)
+{
+}
+
+} // namespace pagmo
+
+PAGMO_S11N_ALGORITHM_IMPLEMENT(pagmo::null_algorithm)

--- a/src/bfe.cpp
+++ b/src/bfe.cpp
@@ -95,8 +95,8 @@ std::string bfe::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
-// Check if the bfe contains a UDBFE.
-bool bfe::has_value() const
+// Check if the bfe is in a valid state.
+bool bfe::is_valid() const
 {
     return static_cast<bool>(m_ptr);
 }

--- a/src/bfe.cpp
+++ b/src/bfe.cpp
@@ -95,6 +95,12 @@ std::string bfe::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
+// Check if the bfe contains a UDBFE.
+bool bfe::has_value() const
+{
+    return static_cast<bool>(m_ptr);
+}
+
 #if !defined(PAGMO_DOXYGEN_INVOKED)
 
 // Stream operator.

--- a/src/island.cpp
+++ b/src/island.cpp
@@ -591,4 +591,13 @@ std::ostream &operator<<(std::ostream &os, const island &isl)
     return os;
 }
 
+/// Check if the island is in a valid state.
+/**
+ * @return ``false`` if ``this`` was moved from, ``true`` otherwise.
+ */
+bool island::is_valid() const
+{
+    return static_cast<bool>(m_ptr);
+}
+
 } // namespace pagmo

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -51,12 +51,12 @@ namespace pagmo
 
 /// Default constructor
 /**
- * Constructs an empty population with a pagmo::null_problem.
+ * Constructs an empty population with a default-constructed problem.
  * The random seed is initialised to zero.
  *
  * @throws unspecified any exception thrown by the constructor from problem.
  */
-population::population() : population(null_problem{}, 0u, 0u) {}
+population::population() : population(problem{}, 0u, 0u) {}
 
 void population::prob_ctor_impl(size_type pop_size)
 {

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -766,6 +766,15 @@ std::string problem::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
+/// Check if the problem contains a UDP.
+/**
+ * @return ``true`` if the problem contains a UDP, ``false`` otherwise (i.e., if ``this`` was moved from).
+ */
+bool problem::has_value() const
+{
+    return static_cast<bool>(m_ptr);
+}
+
 /// Streaming operator
 /**
  * This function will stream to \p os a human-readable representation of the input

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -44,52 +44,13 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/exceptions.hpp>
 #include <pagmo/io.hpp>
 #include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/types.hpp>
 #include <pagmo/utils/constrained.hpp>
 
 namespace pagmo
 {
-
-null_problem::null_problem(vector_double::size_type nobj, vector_double::size_type nec, vector_double::size_type nic,
-                           vector_double::size_type nix)
-    : m_nobj(nobj), m_nec(nec), m_nic(nic), m_nix(nix)
-{
-    if (!nobj) {
-        pagmo_throw(std::invalid_argument, "The null problem must have a non-zero number of objectives");
-    }
-    if (nix > 1u) {
-        pagmo_throw(std::invalid_argument, "The null problem must have an integer part strictly smaller than 2");
-    }
-}
-
-/// Fitness.
-/**
- * @return a zero-filled vector of size equal to the number of objectives.
- */
-vector_double null_problem::fitness(const vector_double &) const
-{
-    return vector_double(get_nobj() + get_nec() + get_nic(), 0.);
-}
-
-/// Problem bounds.
-/**
- * @return the pair <tt>([0.],[1.])</tt>.
- */
-std::pair<vector_double, vector_double> null_problem::get_bounds() const
-{
-    return {{0.}, {1.}};
-}
-
-/// Serialization
-/**
- * @param ar the target serialization archive.
- */
-template <typename Archive>
-void null_problem::serialize(Archive &ar, unsigned)
-{
-    detail::archive(ar, m_nobj, m_nec, m_nic, m_nix);
-}
 
 namespace detail
 {
@@ -987,5 +948,3 @@ vector_double prob_invoke_mem_batch_fitness(const problem &p, const vector_doubl
 } // namespace detail
 
 } // namespace pagmo
-
-PAGMO_S11N_PROBLEM_IMPLEMENT(pagmo::null_problem)

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -727,11 +727,11 @@ std::string problem::get_extra_info() const
     return ptr()->get_extra_info();
 }
 
-/// Check if the problem contains a UDP.
+/// Check if the problem is in a valid state.
 /**
- * @return ``true`` if the problem contains a UDP, ``false`` otherwise (i.e., if ``this`` was moved from).
+ * @return ``false`` if ``this`` was moved from, ``true`` otherwise.
  */
-bool problem::has_value() const
+bool problem::is_valid() const
 {
     return static_cast<bool>(m_ptr);
 }

--- a/src/problems/decompose.cpp
+++ b/src/problems/decompose.cpp
@@ -38,6 +38,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/io.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/decompose.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>
 #include <pagmo/types.hpp>

--- a/src/problems/null_problem.cpp
+++ b/src/problems/null_problem.cpp
@@ -1,0 +1,84 @@
+/* Copyright 2017-2018 PaGMO development team
+
+This file is part of the PaGMO library.
+
+The PaGMO library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+  * the GNU Lesser General Public License as published by the Free
+    Software Foundation; either version 3 of the License, or (at your
+    option) any later version.
+
+or
+
+  * the GNU General Public License as published by the Free Software
+    Foundation; either version 3 of the License, or (at your option) any
+    later version.
+
+or both in parallel, as here.
+
+The PaGMO library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the PaGMO library.  If not,
+see https://www.gnu.org/licenses/. */
+
+#include <initializer_list>
+#include <stdexcept>
+#include <utility>
+
+#include <pagmo/exceptions.hpp>
+#include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
+#include <pagmo/s11n.hpp>
+#include <pagmo/types.hpp>
+
+namespace pagmo
+{
+
+null_problem::null_problem(vector_double::size_type nobj, vector_double::size_type nec, vector_double::size_type nic,
+                           vector_double::size_type nix)
+    : m_nobj(nobj), m_nec(nec), m_nic(nic), m_nix(nix)
+{
+    if (!nobj) {
+        pagmo_throw(std::invalid_argument, "The null problem must have a non-zero number of objectives");
+    }
+    if (nix > 1u) {
+        pagmo_throw(std::invalid_argument, "The null problem must have an integer part strictly smaller than 2");
+    }
+}
+
+/// Fitness.
+/**
+ * @return a zero-filled vector of size equal to the number of objectives.
+ */
+vector_double null_problem::fitness(const vector_double &) const
+{
+    return vector_double(get_nobj() + get_nec() + get_nic(), 0.);
+}
+
+/// Problem bounds.
+/**
+ * @return the pair <tt>([0.],[1.])</tt>.
+ */
+std::pair<vector_double, vector_double> null_problem::get_bounds() const
+{
+    return {{0.}, {1.}};
+}
+
+/// Serialization
+/**
+ * @param ar the target serialization archive.
+ */
+template <typename Archive>
+void null_problem::serialize(Archive &ar, unsigned)
+{
+    detail::archive(ar, m_nobj, m_nec, m_nic, m_nix);
+}
+
+} // namespace pagmo
+
+PAGMO_S11N_PROBLEM_IMPLEMENT(pagmo::null_problem)

--- a/src/problems/translate.cpp
+++ b/src/problems/translate.cpp
@@ -60,9 +60,9 @@ namespace pagmo
 
 /// Default constructor.
 /**
- * The default constructor will initialize a non-translated pagmo::null_problem.
+ * The constructor will initialize a non-translated default-constructed pagmo::problem.
  */
-translate::translate() : m_problem(null_problem{}), m_translation({0.}) {}
+translate::translate() : m_translation({0.}) {}
 
 void translate::generic_ctor_impl(const vector_double &translation)
 {

--- a/src/problems/unconstrain.cpp
+++ b/src/problems/unconstrain.cpp
@@ -39,6 +39,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/exceptions.hpp>
 #include <pagmo/io.hpp>
 #include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/unconstrain.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>

--- a/tests/ackley.cpp
+++ b/tests/ackley.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(ackley_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/algorithm.cpp
+++ b/tests/algorithm.cpp
@@ -471,18 +471,18 @@ BOOST_AUTO_TEST_CASE(thread_safety_test)
     BOOST_CHECK(algorithm{ts3{}}.get_thread_safety() == thread_safety::basic);
 }
 
-BOOST_AUTO_TEST_CASE(has_value)
+BOOST_AUTO_TEST_CASE(is_valid)
 {
     algorithm p0;
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     algorithm p1(std::move(p0));
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = algorithm{al_01{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     p1 = std::move(p0);
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = algorithm{al_01{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(generic_assignment)
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(generic_assignment)
     algorithm p0;
     BOOST_CHECK(p0.is<null_algorithm>());
     BOOST_CHECK(&(p0 = al_01{}) == &p0);
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     BOOST_CHECK(p0.is<al_01>());
     BOOST_CHECK((!std::is_assignable<algorithm, void>::value));
     BOOST_CHECK((!std::is_assignable<algorithm, int &>::value));

--- a/tests/algorithm.cpp
+++ b/tests/algorithm.cpp
@@ -41,6 +41,7 @@ see https://www.gnu.org/licenses/. */
 
 #include <pagmo/algorithm.hpp>
 #include <pagmo/algorithms/de.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
 #include <pagmo/exceptions.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
@@ -263,7 +264,7 @@ BOOST_AUTO_TEST_CASE(algorithm_move_assignment_test)
     // We get the memory address where the user algo is stored
     auto a1 = algo.extract<al_01>();
     // We call the move assignment
-    algorithm moved_algo{null_algorithm{}};
+    algorithm moved_algo{};
     moved_algo = std::move(algo);
     // We get the memory address where the user algo is stored
     auto a2 = moved_algo.extract<al_01>();
@@ -285,7 +286,7 @@ BOOST_AUTO_TEST_CASE(algorithm_copy_assignment_test)
     algo.set_verbosity(1u);
 
     // We call the copy assignment opeator
-    algorithm algo_copy{null_algorithm{}};
+    algorithm algo_copy{};
     algo_copy = algo;
     // We extract the user algorithm
     auto a1 = algo.extract<al_01>();
@@ -408,7 +409,7 @@ BOOST_AUTO_TEST_CASE(null_algorithm_construction_and_evolve)
 
 BOOST_AUTO_TEST_CASE(serialization_test)
 {
-    algorithm algo{null_algorithm{}};
+    algorithm algo{};
     BOOST_CHECK_EQUAL(algo.get_name(), "Null algorithm");
     std::stringstream ss;
     {
@@ -424,7 +425,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
 
 BOOST_AUTO_TEST_CASE(extract_test)
 {
-    algorithm p{null_algorithm{}};
+    algorithm p;
     BOOST_CHECK(p.is<null_algorithm>());
     BOOST_CHECK((std::is_same<null_algorithm *, decltype(p.extract<null_algorithm>())>::value));
     BOOST_CHECK((std::is_same<null_algorithm const *,
@@ -464,7 +465,7 @@ struct ts3 {
 
 BOOST_AUTO_TEST_CASE(thread_safety_test)
 {
-    BOOST_CHECK(algorithm{null_algorithm{}}.get_thread_safety() == thread_safety::basic);
+    BOOST_CHECK(algorithm{}.get_thread_safety() == thread_safety::basic);
     BOOST_CHECK(algorithm{ts1{}}.get_thread_safety() == thread_safety::basic);
     BOOST_CHECK(algorithm{ts2{}}.get_thread_safety() == thread_safety::none);
     BOOST_CHECK(algorithm{ts3{}}.get_thread_safety() == thread_safety::basic);

--- a/tests/algorithm.cpp
+++ b/tests/algorithm.cpp
@@ -470,3 +470,30 @@ BOOST_AUTO_TEST_CASE(thread_safety_test)
     BOOST_CHECK(algorithm{ts2{}}.get_thread_safety() == thread_safety::none);
     BOOST_CHECK(algorithm{ts3{}}.get_thread_safety() == thread_safety::basic);
 }
+
+BOOST_AUTO_TEST_CASE(has_value)
+{
+    algorithm p0;
+    BOOST_CHECK(p0.has_value());
+    algorithm p1(std::move(p0));
+    BOOST_CHECK(!p0.has_value());
+    p0 = algorithm{al_01{}};
+    BOOST_CHECK(p0.has_value());
+    p1 = std::move(p0);
+    BOOST_CHECK(!p0.has_value());
+    p0 = algorithm{al_01{}};
+    BOOST_CHECK(p0.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(generic_assignment)
+{
+    algorithm p0;
+    BOOST_CHECK(p0.is<null_algorithm>());
+    BOOST_CHECK(&(p0 = al_01{}) == &p0);
+    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is<al_01>());
+    BOOST_CHECK((!std::is_assignable<algorithm, void>::value));
+    BOOST_CHECK((!std::is_assignable<algorithm, int &>::value));
+    BOOST_CHECK((!std::is_assignable<algorithm, const int &>::value));
+    BOOST_CHECK((!std::is_assignable<algorithm, int &&>::value));
+}

--- a/tests/bee_colony.cpp
+++ b/tests/bee_colony.cpp
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(bee_colony_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/bfe.cpp
+++ b/tests/bfe.cpp
@@ -474,3 +474,34 @@ BOOST_AUTO_TEST_CASE(lambda_std_function)
         BOOST_CHECK(bfe0(problem{null_problem{3}}, vector_double{.5}) == (vector_double{1., 1., 1.}));
     }
 }
+
+BOOST_AUTO_TEST_CASE(has_value)
+{
+    bfe p0;
+    BOOST_CHECK(p0.has_value());
+    bfe p1(std::move(p0));
+    BOOST_CHECK(!p0.has_value());
+    p0 = bfe{udbfe_a{}};
+    BOOST_CHECK(p0.has_value());
+    p1 = std::move(p0);
+    BOOST_CHECK(!p0.has_value());
+    p0 = bfe{udbfe_a{}};
+    BOOST_CHECK(p0.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(generic_assignment)
+{
+    bfe p0;
+    BOOST_CHECK(p0.is<default_bfe>());
+    BOOST_CHECK(&(p0 = udbfe_a{}) == &p0);
+    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is<udbfe_a>());
+    p0 = udbfe0;
+    BOOST_CHECK(p0.is<udbfe_func_t>());
+    p0 = &udbfe0;
+    BOOST_CHECK(p0.is<udbfe_func_t>());
+    BOOST_CHECK((!std::is_assignable<bfe, void>::value));
+    BOOST_CHECK((!std::is_assignable<bfe, int &>::value));
+    BOOST_CHECK((!std::is_assignable<bfe, const int &>::value));
+    BOOST_CHECK((!std::is_assignable<bfe, int &&>::value));
+}

--- a/tests/bfe.cpp
+++ b/tests/bfe.cpp
@@ -475,18 +475,18 @@ BOOST_AUTO_TEST_CASE(lambda_std_function)
     }
 }
 
-BOOST_AUTO_TEST_CASE(has_value)
+BOOST_AUTO_TEST_CASE(is_valid)
 {
     bfe p0;
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     bfe p1(std::move(p0));
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = bfe{udbfe_a{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     p1 = std::move(p0);
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = bfe{udbfe_a{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(generic_assignment)
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE(generic_assignment)
     bfe p0;
     BOOST_CHECK(p0.is<default_bfe>());
     BOOST_CHECK(&(p0 = udbfe_a{}) == &p0);
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     BOOST_CHECK(p0.is<udbfe_a>());
     p0 = udbfe0;
     BOOST_CHECK(p0.is<udbfe_func_t>());

--- a/tests/bfe.cpp
+++ b/tests/bfe.cpp
@@ -50,6 +50,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/batch_evaluators/default_bfe.hpp>
 #include <pagmo/bfe.hpp>
 #include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>

--- a/tests/cec2006.cpp
+++ b/tests/cec2006.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(cec2006_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/cec2009.cpp
+++ b/tests/cec2009.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(cec2009_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/cec2013.cpp
+++ b/tests/cec2013.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(cec2013_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/cec2014.cpp
+++ b/tests/cec2014.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(cec2014_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/cmaes.cpp
+++ b/tests/cmaes.cpp
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(cmaes_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/compass_search.cpp
+++ b/tests/compass_search.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(compass_search_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/cstrs_self_adaptive.cpp
+++ b/tests/cstrs_self_adaptive.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(cstrs_self_adaptive_serialization)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/de.cpp
+++ b/tests/de.cpp
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(de_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/de1220.cpp
+++ b/tests/de1220.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/decompose.cpp
+++ b/tests/decompose.cpp
@@ -40,6 +40,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/io.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/decompose.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/zdt.hpp>
 #include <pagmo/types.hpp>
@@ -210,7 +211,7 @@ BOOST_AUTO_TEST_CASE(decompose_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/dtlz.cpp
+++ b/tests/dtlz.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(dtlz_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/gaco.cpp
+++ b/tests/gaco.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/golomb_ruler.cpp
+++ b/tests/golomb_ruler.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(golomb_ruler_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/griewank.cpp
+++ b/tests/griewank.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(griewank_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/gwo.cpp
+++ b/tests/gwo.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(gwo_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/hock_schittkowsky_71.cpp
+++ b/tests/hock_schittkowsky_71.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(hock_schittkowsky_71_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/ihs.cpp
+++ b/tests/ihs.cpp
@@ -38,6 +38,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/hock_schittkowsky_71.hpp>
 #include <pagmo/problems/inventory.hpp>
 #include <pagmo/problems/minlp_rastrigin.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/zdt.hpp>
 

--- a/tests/ihs.cpp
+++ b/tests/ihs.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(ihs_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/inventory.cpp
+++ b/tests/inventory.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(inventory_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/ipopt.cpp
+++ b/tests/ipopt.cpp
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(ipopt_serialization)
                 oarchive << algo;
             }
             // Change the content of p before deserializing.
-            algo = algorithm{null_algorithm{}};
+            algo = algorithm{};
             {
                 boost::archive::binary_iarchive iarchive(ss);
                 iarchive >> algo;
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(ipopt_serialization)
                 oarchive << algo;
             }
             // Change the content of p before deserializing.
-            algo = algorithm{null_algorithm{}};
+            algo = algorithm{};
             {
                 boost::archive::binary_iarchive iarchive(ss);
                 iarchive >> algo;

--- a/tests/island.cpp
+++ b/tests/island.cpp
@@ -502,3 +502,17 @@ BOOST_AUTO_TEST_CASE(island_bfe_ctors)
         BOOST_CHECK(pop.get_f()[i] == pop.get_problem().fitness(pop.get_x()[i]));
     }
 }
+
+BOOST_AUTO_TEST_CASE(is_valid)
+{
+    island p0;
+    BOOST_CHECK(p0.is_valid());
+    island p1(std::move(p0));
+    BOOST_CHECK(!p0.is_valid());
+    p0 = island{udi_01{}, de{}, population{rosenbrock{}, 25}};
+    BOOST_CHECK(p0.is_valid());
+    p1 = std::move(p0);
+    BOOST_CHECK(!p0.is_valid());
+    p0 = island{udi_01{}, de{}, population{rosenbrock{}, 25}};
+    BOOST_CHECK(p0.is_valid());
+}

--- a/tests/island.cpp
+++ b/tests/island.cpp
@@ -43,6 +43,7 @@ see https://www.gnu.org/licenses/. */
 #include <boost/lexical_cast.hpp>
 
 #include <pagmo/algorithms/de.hpp>
+#include <pagmo/algorithms/null_algorithm.hpp>
 #include <pagmo/batch_evaluators/thread_bfe.hpp>
 #include <pagmo/bfe.hpp>
 #include <pagmo/config.hpp>

--- a/tests/island.cpp
+++ b/tests/island.cpp
@@ -51,6 +51,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/islands/thread_island.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>

--- a/tests/lennard_jones.cpp
+++ b/tests/lennard_jones.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(lennard_jones_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/luksan_vlcek1.cpp
+++ b/tests/luksan_vlcek1.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(luksan_vlcek1_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/mbh.cpp
+++ b/tests/mbh.cpp
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(mbh_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/minlp_rastrigin.cpp
+++ b/tests/minlp_rastrigin.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(rastrigin_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/moead.cpp
+++ b/tests/moead.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(moead_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/nlopt.cpp
+++ b/tests/nlopt.cpp
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(nlopt_serialization)
                 oarchive << algo;
             }
             // Change the content of p before deserializing.
-            algo = algorithm{null_algorithm{}};
+            algo = algorithm{};
             {
                 boost::archive::binary_iarchive iarchive(ss);
                 iarchive >> algo;
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(nlopt_serialization)
                 oarchive << algo;
             }
             // Change the content of p before deserializing.
-            algo = algorithm{null_algorithm{}};
+            algo = algorithm{};
             {
                 boost::archive::binary_iarchive iarchive(ss);
                 iarchive >> algo;
@@ -348,7 +348,7 @@ BOOST_AUTO_TEST_CASE(nlopt_loc_opt)
             oarchive << algo;
         }
         // Change the content of p before deserializing.
-        algo = algorithm{null_algorithm{}};
+        algo = algorithm{};
         {
             boost::archive::binary_iarchive iarchive(ss);
             iarchive >> algo;

--- a/tests/nlopt.cpp
+++ b/tests/nlopt.cpp
@@ -47,6 +47,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/hock_schittkowsky_71.hpp>
 #include <pagmo/problems/luksan_vlcek1.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/zdt.hpp>
 #include <pagmo/rng.hpp>

--- a/tests/nsga2.cpp
+++ b/tests/nsga2.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(nsga2_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/population.cpp
+++ b/tests/population.cpp
@@ -44,6 +44,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/hock_schittkowsky_71.hpp>
 #include <pagmo/problems/inventory.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/zdt.hpp>
 #include <pagmo/s11n.hpp>
@@ -187,7 +188,7 @@ BOOST_AUTO_TEST_CASE(population_push_back_test)
 BOOST_AUTO_TEST_CASE(population_random_decision_vector_test)
 {
     // Create an empty population
-    population pop{problem{null_problem{}}};
+    population pop{problem{}};
     auto bounds = pop.get_problem().get_bounds();
     // Generate a random decision_vector
     auto x = pop.random_decision_vector();
@@ -203,7 +204,7 @@ BOOST_AUTO_TEST_CASE(population_best_worst_test)
     // Test throw
     {
         population pop{problem{zdt{}}, 2};
-        population pop2{problem{null_problem{}}, 0u};
+        population pop2{problem{}, 0u};
         BOOST_CHECK_THROW(pop.best_idx(), std::invalid_argument);
         BOOST_CHECK_THROW(pop.worst_idx(), std::invalid_argument);
         BOOST_CHECK_THROW(pop2.best_idx(), std::invalid_argument);
@@ -229,7 +230,7 @@ BOOST_AUTO_TEST_CASE(population_best_worst_test)
 
 BOOST_AUTO_TEST_CASE(population_setters_test)
 {
-    population pop{problem{null_problem{}}, 2};
+    population pop{problem{}, 2};
     // Test throw
     BOOST_CHECK_THROW(pop.set_xf(2, {3}, {1, 2, 3}), std::invalid_argument); // index invalid
     BOOST_CHECK_THROW(pop.set_xf(1, {3, 2}, {1}), std::invalid_argument);    // chromosome invalid
@@ -246,7 +247,7 @@ BOOST_AUTO_TEST_CASE(population_setters_test)
 
 BOOST_AUTO_TEST_CASE(population_getters_test)
 {
-    population pop{problem{null_problem{}}, 1, 1234u};
+    population pop{problem{}, 1, 1234u};
     pop.set_xf(0, {3}, {1});
     // Test
     BOOST_CHECK((pop.get_f()[0] == vector_double{1}));
@@ -330,7 +331,7 @@ BOOST_AUTO_TEST_CASE(population_champion_test)
 
 BOOST_AUTO_TEST_CASE(population_serialization_test)
 {
-    population pop{problem{null_problem{}}, 30, 1234u};
+    population pop{problem{}, 30, 1234u};
     // Store the string representation of p.
     std::stringstream ss;
     auto before = boost::lexical_cast<std::string>(pop);

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -1565,3 +1565,30 @@ BOOST_AUTO_TEST_CASE(batch_fitness)
     BOOST_CHECK_EQUAL(before, after);
     BOOST_CHECK(p.has_batch_fitness());
 }
+
+BOOST_AUTO_TEST_CASE(has_value)
+{
+    problem p0;
+    BOOST_CHECK(p0.has_value());
+    problem p1(std::move(p0));
+    BOOST_CHECK(!p0.has_value());
+    p0 = problem{full_p{}};
+    BOOST_CHECK(p0.has_value());
+    p1 = std::move(p0);
+    BOOST_CHECK(!p0.has_value());
+    p0 = problem{full_p{}};
+    BOOST_CHECK(p0.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(generic_assignment)
+{
+    problem p0;
+    BOOST_CHECK(p0.is<null_problem>());
+    BOOST_CHECK(&(p0 = full_p{}) == &p0);
+    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is<full_p>());
+    BOOST_CHECK((!std::is_assignable<problem, void>::value));
+    BOOST_CHECK((!std::is_assignable<problem, int &>::value));
+    BOOST_CHECK((!std::is_assignable<problem, const int &>::value));
+    BOOST_CHECK((!std::is_assignable<problem, int &&>::value));
+}

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -44,6 +44,7 @@ see https://www.gnu.org/licenses/. */
 
 #include <pagmo/exceptions.hpp>
 #include <pagmo/problem.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>
 #include <pagmo/types.hpp>
@@ -1010,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(problem_feasibility_methods_test)
 BOOST_AUTO_TEST_CASE(null_problem_test)
 {
     // Problem instantiation
-    problem p{null_problem{}};
+    problem p;
     BOOST_CHECK_EQUAL(p.get_name(), "Null problem");
     // Pick a few reference points
     vector_double x1 = {1};
@@ -1049,7 +1050,7 @@ BOOST_AUTO_TEST_CASE(null_problem_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     BOOST_CHECK_EQUAL(p.get_nobj(), 1u);
     {
         boost::archive::binary_iarchive iarchive(ss);
@@ -1065,7 +1066,7 @@ BOOST_AUTO_TEST_CASE(null_problem_serialization_test)
 
 BOOST_AUTO_TEST_CASE(extract_test)
 {
-    problem p{null_problem{}};
+    problem p;
     BOOST_CHECK(p.is<null_problem>());
     BOOST_CHECK(!p.is<base_p>());
     BOOST_CHECK((std::is_same<null_problem *, decltype(p.extract<null_problem>())>::value));
@@ -1120,7 +1121,7 @@ struct ts3 {
 
 BOOST_AUTO_TEST_CASE(thread_safety_test)
 {
-    BOOST_CHECK(problem{null_problem{}}.get_thread_safety() == thread_safety::basic);
+    BOOST_CHECK(problem{}.get_thread_safety() == thread_safety::basic);
     BOOST_CHECK(problem{ts1{}}.get_thread_safety() == thread_safety::basic);
     BOOST_CHECK(problem{ts2{}}.get_thread_safety() == thread_safety::none);
     BOOST_CHECK(problem{ts3{}}.get_thread_safety() == thread_safety::basic);

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -1567,18 +1567,18 @@ BOOST_AUTO_TEST_CASE(batch_fitness)
     BOOST_CHECK(p.has_batch_fitness());
 }
 
-BOOST_AUTO_TEST_CASE(has_value)
+BOOST_AUTO_TEST_CASE(is_valid)
 {
     problem p0;
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     problem p1(std::move(p0));
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = problem{full_p{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     p1 = std::move(p0);
-    BOOST_CHECK(!p0.has_value());
+    BOOST_CHECK(!p0.is_valid());
     p0 = problem{full_p{}};
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(generic_assignment)
@@ -1586,7 +1586,7 @@ BOOST_AUTO_TEST_CASE(generic_assignment)
     problem p0;
     BOOST_CHECK(p0.is<null_problem>());
     BOOST_CHECK(&(p0 = full_p{}) == &p0);
-    BOOST_CHECK(p0.has_value());
+    BOOST_CHECK(p0.is_valid());
     BOOST_CHECK(p0.is<full_p>());
     BOOST_CHECK((!std::is_assignable<problem, void>::value));
     BOOST_CHECK((!std::is_assignable<problem, int &>::value));

--- a/tests/pso.cpp
+++ b/tests/pso.cpp
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/pso_gen.cpp
+++ b/tests/pso_gen.cpp
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/rastrigin.cpp
+++ b/tests/rastrigin.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(rastrigin_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/rosenbrock.cpp
+++ b/tests/rosenbrock.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(rosenbrock_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/sade.cpp
+++ b/tests/sade.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/schwefel.cpp
+++ b/tests/schwefel.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(schwefel_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/sea.cpp
+++ b/tests/sea.cpp
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(sea_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/sga.cpp
+++ b/tests/sga.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(sga_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/simulated_annealing.cpp
+++ b/tests/simulated_annealing.cpp
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(simulated_annealing_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/translate.cpp
+++ b/tests/translate.cpp
@@ -43,6 +43,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problems/cec2009.hpp>
 #include <pagmo/problems/hock_schittkowsky_71.hpp>
 #include <pagmo/problems/inventory.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/translate.hpp>
 #include <pagmo/threading.hpp>
 #include <pagmo/types.hpp>
@@ -120,7 +121,7 @@ BOOST_AUTO_TEST_CASE(translate_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/unconstrain.cpp
+++ b/tests/unconstrain.cpp
@@ -41,6 +41,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/cec2006.hpp>
 #include <pagmo/problems/cec2009.hpp>
+#include <pagmo/problems/null_problem.hpp>
 #include <pagmo/problems/rosenbrock.hpp>
 #include <pagmo/problems/unconstrain.hpp>
 #include <pagmo/problems/zdt.hpp>
@@ -183,7 +184,7 @@ BOOST_AUTO_TEST_CASE(unconstrain_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;

--- a/tests/xnes.cpp
+++ b/tests/xnes.cpp
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(xnes_serialization_test)
         oarchive << algo;
     }
     // Change the content of p before deserializing.
-    algo = algorithm{null_algorithm{}};
+    algo = algorithm{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> algo;

--- a/tests/zdt.cpp
+++ b/tests/zdt.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(zdt_serialization_test)
         oarchive << p;
     }
     // Change the content of p before deserializing.
-    p = problem{null_problem{}};
+    p = problem{};
     {
         boost::archive::binary_iarchive iarchive(ss);
         iarchive >> p;


### PR DESCRIPTION
This PR adds a couple of capabilities on the C++ side:

- generic assignment of a UDP/UDA/... to a ``problem``/``algorithm``/..., so that now it is possible to write:

```c++
problem p;
p = rosenbrock{};
```

- a new function ``is_valid()`` for user-defined classes, with which it is possible to query if the object was moved from:

```c++
problem p;
assert(p.is_valid());
problem p2 = std::move(p);
assert(!p.is_valid());
```

We already stated in the documentation that moved-from objects could only be destroyed and assigned to (revived). Now it is also possible to call ``is_valid()`` to query the current state of the object.

None of these features are meaningful in Python, so pygmo was not touched by these additions.

I also moved ``null_problem`` and ``null_algorithm`` to their own headers (they previously resided in ``problem.hpp`` and ``algorithm.hpp``), and made some other smaller internal changes.