### PR TITLE
bug fix for gaco

### DIFF
--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -613,7 +613,7 @@ void gaco::update_sol_archive(const population &pop, vector_double &sorted_vecto
             if (i > saved_value_position.back()) {
                 // I check if the new penalties are better than the old ones of at least m_acc difference (user
                 // defined parameter).
-                while (temporary_penalty[j] - temporary_archive[k - 1][0] < m_acc && j < 2 * m_ker) {
+                while (temporary_penalty[j] + m_acc < temporary_archive[k - 1][0] && j < 2 * m_ker) {
                     ++j;
                 }
                 saved_value_position.push_back(j);
@@ -630,8 +630,7 @@ void gaco::update_sol_archive(const population &pop, vector_double &sorted_vecto
         for (decltype(m_ker) i = 0u; i < m_ker; ++i) {
             count_2 = false;
             for (decltype(m_ker) jj = 0u; jj < m_ker && count_2 == false; ++jj) {
-                if (temporary_archive[i][0] == sol_archive[jj][0]) {
-                    temporary_archive[i] = sol_archive[jj];
+                if (temporary_archive[i] == sol_archive[jj]) {
                     count_2 = true;
                 } else if (temporary_archive[i][0] == sorted_vector[jj]) {
                     for (decltype(variables[0].size()) i_var = 0u; i_var < variables[0].size(); ++i_var) {


### PR DESCRIPTION
In the algo, in an if cycle, it was only checked one element of a vector, instead of the whole vector. 
This is a bug, since there are cases in which two vectors have the same initial element (in this case penalty) but they are different, and the algo was not able to recognize that. 
This was not easy to spot at first since, in general, each ant has a different penalty (and thus the first element of the vector is indeed different): but this is not always true, and there might be cases in which the penalty is the same for two different ants.