### PR TITLE
MO parameters removal from GACO

### DIFF
--- a/doc/sphinx/docs/python/tutorials/cec2006_gaco_benchmark.rst
+++ b/doc/sphinx/docs/python/tutorials/cec2006_gaco_benchmark.rst
@@ -30,9 +30,9 @@ In order to run the UDAs on these problems we can write the following piece of c
     ...       udp = problems[index]
     ...       prob = pg.problem(udp)
     ...       #Instantiate pagmo algorithms:
-    ...       uda_gaco = pg.gaco(550, 100, 1.0, real_minima[index], 0.0, 200, 7, 10000, 10000, 0.0, 10, 0.9, False, 23)
+    ...       uda_gaco = pg.gaco(550, 100, 1.0, real_minima[index], 0.0, 200, 7, 10000, 10000, 0.0, False, 23)
     ...       uda_cstrs_sade=pg.cstrs_self_adaptive(40,pg.sade(10, 2, 1, 1e-6, 1e-6, False, 23))
-    ...       uda_cstrs_gaco=pg.cstrs_self_adaptive(40,pg.gaco(10, 125, 1.0, real_minima[index], 0.0, 8, 7, 10000, 10000, 0.0, 10, 0.9, False, 23))
+    ...       uda_cstrs_gaco=pg.cstrs_self_adaptive(40,pg.gaco(10, 125, 1.0, real_minima[index], 0.0, 8, 7, 10000, 10000, 0.0, False, 23))
     ...       algo_gaco=pg.algorithm(uda_gaco)
     ...       algo_cstrs_sade=pg.algorithm(uda_cstrs_sade)
     ...       algo_cstrs_gaco=pg.algorithm(uda_cstrs_gaco)

--- a/include/pagmo/algorithms/gaco.hpp
+++ b/include/pagmo/algorithms/gaco.hpp
@@ -91,7 +91,7 @@ public:
     typedef std::vector<log_line_type> log_type;
 
     /**
-     * Constructs the ACO user defined algorithm for single and multi-objective optimization.
+     * Constructs the ACO user defined algorithm for single-objective optimization.
      *
      * @param[in] gen Generations: number of generations to evolve.
      * @param[in] ker Kernel: number of solutions stored in the solution archive.
@@ -109,23 +109,18 @@ public:
      * @param[in] focus Focus parameter: this parameter makes the search for the optimum greedier and more focused on
      * local improvements (the higher the greedier). If the value is very high, the search is more focused around the
      * current best solutions.
-     * @param[in] paretomax Max number of non-dominated solutions: this regulates the max number of Pareto points to be
-     * stored.
-     * @param[in] epsilon Pareto precision parameter: the smaller this parameter, the higher the chances to introduce a
-     * new solution in the Pareto front.
      * @param[in] memory Memory parameter: if true, memory is activated in the algorithm for multiple calls
      * @param seed seed used by the internal random number generator (default is random).
      *
      * @throws std::invalid_argument if \p acc is not \f$ >=0 \f$, \p impstop is not a
      * positive integer, \p evalstop is not a positive integer, \p focus is not \f$ >=0 \f$,
-     * \p ker is not a positive integer, \p oracle is not positive, \p paretomax is not a positive integer, \p
+     * \p ker is not a positive integer, \p oracle is not positive, \p
      * threshold is not \f$ \in [1,gen] \f$ when \f$memory=false\f$ and  \f$gen!=0\f$, \p threshold is not \f$ >=1 \f$
-     * when \f$memory=true\f$ and \f$gen!=0\f$, \p epsilon is not \f$ \in [0,1[\f$, \p q is not \f$ >=0 \f$
+     * when \f$memory=true\f$ and \f$gen!=0\f$, \p q is not \f$ >=0 \f$
      */
-    gaco(unsigned gen = 100u, unsigned ker = 63u, double q = 1.0, double oracle = 0., double acc = 0.01,
+    gaco(unsigned gen = 1u, unsigned ker = 63u, double q = 1.0, double oracle = 0., double acc = 0.01,
          unsigned threshold = 1u, unsigned n_gen_mark = 7u, unsigned impstop = 100000u, unsigned evalstop = 100000u,
-         double focus = 0., unsigned paretomax = 10u, double epsilon = 0.9, bool memory = false,
-         unsigned seed = pagmo::random_device::next());
+         double focus = 0., bool memory = false, unsigned seed = pagmo::random_device::next());
 
     // Algorithm evolve method
     population evolve(population) const;
@@ -249,8 +244,6 @@ private:
     double m_focus;
     unsigned m_ker;
     mutable double m_oracle;
-    unsigned m_paretomax;
-    double m_epsilon;
     mutable detail::random_engine_type m_e;
     unsigned m_seed;
     unsigned m_verbosity;

--- a/pygmo/docstrings.cpp
+++ b/pygmo/docstrings.cpp
@@ -2480,7 +2480,7 @@ Raises:
 
 std::string gaco_docstring()
 {
-    return R"(__init__(gen = 100, ker = 63, q = 1.0, oracle = 0., acc = 0.01, threshold = 1u, n_gen_mark = 7u, impstop = 100000u, evalstop = 100000u, focus = 0., paretomax = 10u, epsilon = 0.9, memory = false, seed = random)
+    return R"(__init__(gen = 1, ker = 63, q = 1.0, oracle = 0., acc = 0.01, threshold = 1u, n_gen_mark = 7u, impstop = 100000u, evalstop = 100000u, focus = 0., memory = false, seed = random)
 
 Extended Ant Colony Optimization algorithm (gaco).
 
@@ -2521,14 +2521,12 @@ Args:
     impstop (``int``): improvement stopping criterion
     evalstop (``int``): evaluation stopping criterion
     focus (``float``): focus parameter
-    paretomax (``int``): max number of non-dominated solutions
-    epsilon (``float``): pareto decision parameter
     memory (``bool``): memory parameter
     seed (``int``): seed used by the internal random number generator (default is random)
 
 Raises:
     OverflowError: if *gen* or *seed* are negative or greater than an implementation-defined value
-    ValueError: if either *acc* is not >=0, *focus* is not >=0, *epsilon* is not in [0,1],
+    ValueError: if either *acc* is not >=0, *focus* is not >=0 or *q* is not >=0,
       *threshold* is not in [1,gen] when gen!=0 and memory==false, or
       *threshold* is not in >=1 when gen!=0 and memory==true
 
@@ -2560,7 +2558,7 @@ Examples:
     >>> import pygmo as pg
     >>> prob = pg.problem(pg.rosenbrock(dim = 2))
     >>> pop = pg.population(prob, size=13, seed=23)
-    >>> algo = pg.algorithm(pg.gaco(10, 13, 1.0, 1e9, 0.0, 1, 7, 100000, 100000, 0.0, 10, 0.9, False, 23))
+    >>> algo = pg.algorithm(pg.gaco(10, 13, 1.0, 1e9, 0.0, 1, 7, 100000, 100000, 0.0, False, 23))
     >>> algo.set_verbosity(1)
     >>> pop = algo.evolve(pop) # doctest: +SKIP
      Gen:        Fevals:          Best:        Kernel:        Oracle:            dx:            dp:

--- a/pygmo/expose_algorithms_1.cpp
+++ b/pygmo/expose_algorithms_1.cpp
@@ -204,17 +204,15 @@ void expose_algorithms_1()
     // GACO
     auto gaco_ = expose_algorithm_pygmo<gaco>("gaco", gaco_docstring().c_str());
     gaco_.def(
-        bp::init<unsigned, unsigned, double, double, double, unsigned, unsigned, unsigned, unsigned, double, unsigned,
-                 double, bool>((bp::arg("gen") = 100u, bp::arg("ker") = 63u, bp::arg("q") = 1.0, bp::arg("oracle") = 0.,
-                                bp::arg("acc") = 0.01, bp::arg("threshold") = 1u, bp::arg("n_gen_mark") = 7u,
-                                bp::arg("impstop") = 100000u, bp::arg("evalstop") = 100000u, bp::arg("focus") = 0.,
-                                bp::arg("paretomax") = 10u, bp::arg("epsilon") = 0.9, bp::arg("memory") = false)));
-    gaco_.def(bp::init<unsigned, unsigned, double, double, double, unsigned, unsigned, unsigned, unsigned, double,
-                       unsigned, double, bool, unsigned>(
+        bp::init<unsigned, unsigned, double, double, double, unsigned, unsigned, unsigned, unsigned, double, bool>(
+            (bp::arg("gen") = 100u, bp::arg("ker") = 63u, bp::arg("q") = 1.0, bp::arg("oracle") = 0.,
+             bp::arg("acc") = 0.01, bp::arg("threshold") = 1u, bp::arg("n_gen_mark") = 7u, bp::arg("impstop") = 100000u,
+             bp::arg("evalstop") = 100000u, bp::arg("focus") = 0., bp::arg("memory") = false)));
+    gaco_.def(bp::init<unsigned, unsigned, double, double, double, unsigned, unsigned, unsigned, unsigned, double, bool,
+                       unsigned>(
         (bp::arg("gen") = 100u, bp::arg("ker") = 63u, bp::arg("q") = 1.0, bp::arg("oracle") = 0., bp::arg("acc") = 0.01,
          bp::arg("threshold") = 1u, bp::arg("n_gen_mark") = 7u, bp::arg("impstop") = 100000u,
-         bp::arg("evalstop") = 100000u, bp::arg("focus") = 0., bp::arg("paretomax") = 10u, bp::arg("epsilon") = 0.9,
-         bp::arg("memory") = false, bp::arg("seed"))));
+         bp::arg("evalstop") = 100000u, bp::arg("focus") = 0., bp::arg("memory") = false, bp::arg("seed"))));
     expose_algo_log(gaco_, gaco_get_log_docstring().c_str());
     gaco_.def("get_seed", &gaco::get_seed, generic_uda_get_seed_docstring().c_str());
     gaco_.def("set_bfe", &gaco::set_bfe, gaco_set_bfe_docstring().c_str(), bp::arg("b"));
@@ -243,17 +241,16 @@ void expose_algorithms_1()
     nlopt_.def("get_last_opt_result", lcast([](const nlopt &n) { return static_cast<int>(n.get_last_opt_result()); }),
                nlopt_get_last_opt_result_docstring().c_str());
     nlopt_.def("get_solver_name", &nlopt::get_solver_name, nlopt_get_solver_name_docstring().c_str());
-    add_property(
-        nlopt_, "local_optimizer",
-        bp::make_function(lcast([](nlopt &n) { return n.get_local_optimizer(); }), bp::return_internal_reference<>()),
-        lcast([](nlopt &n, const nlopt *ptr) {
-            if (ptr) {
-                n.set_local_optimizer(*ptr);
-            } else {
-                n.unset_local_optimizer();
-            }
-        }),
-        nlopt_local_optimizer_docstring().c_str());
+    add_property(nlopt_, "local_optimizer", bp::make_function(lcast([](nlopt &n) { return n.get_local_optimizer(); }),
+                                                              bp::return_internal_reference<>()),
+                 lcast([](nlopt &n, const nlopt *ptr) {
+                     if (ptr) {
+                         n.set_local_optimizer(*ptr);
+                     } else {
+                         n.unset_local_optimizer();
+                     }
+                 }),
+                 nlopt_local_optimizer_docstring().c_str());
 #endif
 }
 } // namespace pygmo

--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -55,12 +55,11 @@ namespace pagmo
 {
 
 gaco::gaco(unsigned gen, unsigned ker, double q, double oracle, double acc, unsigned threshold, unsigned n_gen_mark,
-           unsigned impstop, unsigned evalstop, double focus, unsigned paretomax, double epsilon, bool memory,
-           unsigned seed)
+           unsigned impstop, unsigned evalstop, double focus, bool memory, unsigned seed)
     : m_gen(gen), m_acc(acc), m_impstop(impstop), m_evalstop(evalstop), m_focus(focus), m_ker(ker), m_oracle(oracle),
-      m_paretomax(paretomax), m_epsilon(epsilon), m_e(seed), m_seed(seed), m_verbosity(0u), m_log(), m_res(),
-      m_threshold(threshold), m_q(q), m_n_gen_mark(n_gen_mark), m_memory(memory), m_counter(0u), m_sol_archive(),
-      m_n_evalstop(1u), m_n_impstop(1u), m_gen_mark(1u), m_fevals(0u)
+      m_e(seed), m_seed(seed), m_verbosity(0u), m_log(), m_res(), m_threshold(threshold), m_q(q),
+      m_n_gen_mark(n_gen_mark), m_memory(memory), m_counter(0u), m_sol_archive(), m_n_evalstop(1u), m_n_impstop(1u),
+      m_gen_mark(1u), m_fevals(0u)
 {
     if (acc < 0.) {
         pagmo_throw(std::invalid_argument,
@@ -69,12 +68,6 @@ gaco::gaco(unsigned gen, unsigned ker, double q, double oracle, double acc, unsi
     if (focus < 0.) {
         pagmo_throw(std::invalid_argument,
                     "The focus parameter must be >=0  while a value of " + std::to_string(focus) + " was detected");
-    }
-
-    if (epsilon >= 1. || epsilon < 0.) {
-        pagmo_throw(std::invalid_argument,
-                    "The Pareto precision parameter must be in [0, 1[, while a value of " + std::to_string(epsilon)
-                        + " was detected");
     }
     if ((threshold < 1 || threshold > gen) && gen != 0 && memory == false) {
         pagmo_throw(std::invalid_argument,
@@ -85,6 +78,11 @@ gaco::gaco(unsigned gen, unsigned ker, double q, double oracle, double acc, unsi
         pagmo_throw(std::invalid_argument,
                     "If memory is active, the threshold parameter must be >=1 while a value of "
                         + std::to_string(threshold) + " was detected");
+    }
+    if (q < 0.) {
+        pagmo_throw(std::invalid_argument,
+                    "The convergence speed parameter must be >=0  while a value of " + std::to_string(q)
+                        + " was detected");
     }
 }
 
@@ -468,8 +466,6 @@ std::string gaco::get_extra_info() const
     stream(ss, "\n\tFocus parameter: ", m_focus);
     stream(ss, "\n\tKernel: ", m_ker);
     stream(ss, "\n\tOracle parameter: ", m_oracle);
-    stream(ss, "\n\tMax number of non-dominated solutions: ", m_paretomax);
-    stream(ss, "\n\tPareto precision: ", m_epsilon);
     stream(ss, "\n\tPseudo-random number generator (Marsenne Twister 19937): ", m_e);
     stream(ss, "\n\tSeed: ", m_seed);
     stream(ss, "\n\tVerbosity: ", m_verbosity);
@@ -488,9 +484,9 @@ std::string gaco::get_extra_info() const
 template <typename Archive>
 void gaco::serialize(Archive &ar, unsigned)
 {
-    detail::archive(ar, m_gen, m_acc, m_impstop, m_evalstop, m_focus, m_ker, m_oracle, m_paretomax, m_epsilon, m_e,
-                    m_seed, m_verbosity, m_log, m_res, m_threshold, m_q, m_n_gen_mark, m_memory, m_counter,
-                    m_sol_archive, m_n_evalstop, m_n_impstop, m_gen_mark, m_fevals, m_bfe);
+    detail::archive(ar, m_gen, m_acc, m_impstop, m_evalstop, m_focus, m_ker, m_oracle, m_e, m_seed, m_verbosity, m_log,
+                    m_res, m_threshold, m_q, m_n_gen_mark, m_memory, m_counter, m_sol_archive, m_n_evalstop,
+                    m_n_impstop, m_gen_mark, m_fevals, m_bfe);
 }
 
 /**

--- a/tests/gaco.cpp
+++ b/tests/gaco.cpp
@@ -57,24 +57,16 @@ using namespace pagmo;
 // Construction tests: we verify that the algorithm throws an error for wrong input parameters
 BOOST_AUTO_TEST_CASE(construction_test)
 {
-    gaco user_algo{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco user_algo{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, false, 23u};
     BOOST_CHECK(user_algo.get_verbosity() == 0u);
     BOOST_CHECK(user_algo.get_seed() == 23u);
     BOOST_CHECK((user_algo.get_log() == gaco::log_type{}));
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, -0.01, 1u, 7u, 1000u, 1000u, 0.1, 10u, 0.9, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, -0.1, 10u, 0.9, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, 10u, -0.1, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, 10u, 1.1, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 3u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u}),
-                      std::invalid_argument);
-    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, true, 23u}),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, -0.01, 1u, 7u, 1000u, 1000u, 0.1, false, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, -0.1, false, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, -1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 3u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, true, 23u}), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(evolve_test)
@@ -87,17 +79,17 @@ BOOST_AUTO_TEST_CASE(evolve_test)
         population pop2{prob, 10u, 23u};
         population pop3{prob, 10u, 23u};
         for (unsigned i = 1u; i < 3u; ++i) {
-            gaco user_algo1{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+            gaco user_algo1{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, false, 23u};
             user_algo1.set_verbosity(1u);
             pop1 = user_algo1.evolve(pop1);
             BOOST_CHECK(user_algo1.get_log().size() > 0u);
-            gaco user_algo2{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+            gaco user_algo2{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, false, 23u};
             user_algo2.set_verbosity(1u);
             pop2 = user_algo2.evolve(pop2);
 
             BOOST_CHECK(user_algo1.get_log() == user_algo2.get_log());
 
-            gaco user_algo3{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+            gaco user_algo3{3u, 5u, 1.0, 1e9, 0.01, i, 7u, 1000u, 1000u, 0.0, false, 23u};
             user_algo3.set_verbosity(1u);
             pop3 = user_algo3.evolve(pop3);
 
@@ -107,7 +99,7 @@ BOOST_AUTO_TEST_CASE(evolve_test)
     // Here we check that the exit condition of impstop and evalstop actually provoke an exit within 300u gen
     // (rosenbrock{10} and rosenbrock{2} are used)
     {
-        gaco user_algo{200u, 15u, 1.0, 0.0, 0.01, 150u, 7u, 1u, 1000u, 0.0, 10u, 0.9, false, 23u};
+        gaco user_algo{200u, 15u, 1.0, 0.0, 0.01, 150u, 7u, 1u, 1000u, 0.0, false, 23u};
         user_algo.set_verbosity(1u);
         problem prob{rosenbrock{2u}};
         population pop{prob, 20u, 23u};
@@ -115,7 +107,7 @@ BOOST_AUTO_TEST_CASE(evolve_test)
         BOOST_CHECK(user_algo.get_log().size() < 200u);
     }
     {
-        gaco user_algo{200u, 15u, 1.0, 0.0, 0.01, 150u, 7u, 1000u, 1u, 0.0, 10u, 0.9, false, 23u};
+        gaco user_algo{200u, 15u, 1.0, 0.0, 0.01, 150u, 7u, 1000u, 1u, 0.0, false, 23u};
         user_algo.set_verbosity(1u);
         problem prob{rosenbrock{2u}};
         population pop{prob, 20u, 23u};
@@ -139,7 +131,7 @@ BOOST_AUTO_TEST_CASE(evolve_test)
 
 BOOST_AUTO_TEST_CASE(setters_getters_test)
 {
-    gaco user_algo{10u, 13u, 1.0, 0.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco user_algo{10u, 13u, 1.0, 0.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, false, 23u};
     user_algo.set_verbosity(23u);
     BOOST_CHECK(user_algo.get_verbosity() == 23u);
     user_algo.set_seed(23u);
@@ -154,7 +146,7 @@ BOOST_AUTO_TEST_CASE(serialization_test)
     // Make one evolution
     problem prob{rosenbrock{2u}};
     population pop{prob, 15u, 23u};
-    algorithm algo{gaco{10u, 13u, 1.0, 100.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u}};
+    algorithm algo{gaco{10u, 13u, 1.0, 100.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, false, 23u}};
     algo.set_verbosity(1u);
     pop = algo.evolve(pop);
 
@@ -196,33 +188,33 @@ BOOST_AUTO_TEST_CASE(miscellaneous_tests)
     problem prob{hock_schittkowsky_71{}};
     population population1{prob, 15u, 23u};
     prob.set_c_tol(1.0);
-    gaco user_algo1{100u, 13u, 1.0, 1500.0, 0.01, 90u, 1u, 1000u, 1000u, 1000.0, 10u, 0.9, false, 23u};
+    gaco user_algo1{100u, 13u, 1.0, 1500.0, 0.01, 90u, 1u, 1000u, 1000u, 1000.0, false, 23u};
     user_algo1.set_verbosity(1u);
     population1 = user_algo1.evolve(population1);
     population population2{prob, 15u, 23u};
-    gaco user_algo2{100u, 13u, 1.0, 2700.0, 0.01, 90u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco user_algo2{100u, 13u, 1.0, 2700.0, 0.01, 90u, 7u, 1000u, 1000u, 0.0, false, 23u};
     user_algo2.set_verbosity(1u);
     population2 = user_algo2.evolve(population2);
     population population3{prob, 15u, 23u};
-    gaco user_algo3{100u, 13u, 1.0, 1500.0, 0.01, 90u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco user_algo3{100u, 13u, 1.0, 1500.0, 0.01, 90u, 7u, 1000u, 1000u, 0.0, false, 23u};
     user_algo3.set_verbosity(1u);
     population3 = user_algo3.evolve(population3);
     population population4{prob, 150u, 23u};
-    gaco user_algo4{10u, 130u, 1.5, 1500.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u}; // 1
+    gaco user_algo4{10u, 130u, 1.5, 1500.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, false, 23u}; // 1
     user_algo4.set_verbosity(1u);
     population4 = user_algo4.evolve(population4);
     population population5{prob, 150u, 23u};
-    gaco user_algo5{10u, 130u, 1.5, 1500.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u}; // 3
+    gaco user_algo5{10u, 130u, 1.5, 1500.0, 0.01, 9u, 7u, 1000u, 1000u, 0.0, false, 23u}; // 3
     user_algo5.set_verbosity(1u);
     population5 = user_algo5.evolve(population5);
     problem prob_ros{rosenbrock{10u}};
     population population6{prob_ros, 200u, 23u};
-    gaco user_algo6{20u, 150u, 1.0, 0.0, 0.0, 9u, 7u, 10000u, 10000u, 0.0, 10u, 0.9, false, 23u};
+    gaco user_algo6{20u, 150u, 1.0, 0.0, 0.0, 9u, 7u, 10000u, 10000u, 0.0, false, 23u};
     user_algo6.set_verbosity(1u);
     population6 = user_algo6.evolve(population6);
     problem prob_cec{cec2006{1u}};
     population population7{prob_cec, 20u, 23u};
-    gaco user_algo7{20u, 15u, 1.0, 1e9, 0.0, 9u, 7u, 10000u, 10000u, 0.0, 10u, 0.9, false, 23u}; // 3
+    gaco user_algo7{20u, 15u, 1.0, 1e9, 0.0, 9u, 7u, 10000u, 10000u, 0.0, false, 23u}; // 3
     user_algo7.set_verbosity(1u);
     population7 = user_algo7.evolve(population7);
     BOOST_CHECK(user_algo1.get_log().size() > 0u);
@@ -299,10 +291,10 @@ BOOST_AUTO_TEST_CASE(test_for_inf_and_nan)
 // Memory test: we verify that the algorithm has implemented memory correctly
 BOOST_AUTO_TEST_CASE(memory_test)
 {
-    gaco uda{1u, 20u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, 10u, 0.9, true, 23u};
-    gaco uda_2{10u, 20u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, 10u, 0.9, false, 23u};
+    gaco uda{1u, 20u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, true, 23u};
+    gaco uda_2{10u, 20u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, false, 23u};
     // for coverage purposes we introduce also a third one:
-    gaco uda_3{1u, 2u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, 10u, 0.9, false, 23u};
+    gaco uda_3{1u, 2u, 1.0, 1e9, 0.01, 1u, 7u, 1000u, 1000u, 100.0, false, 23u};
     uda.set_seed(23u);
     uda_2.set_seed(23u);
     uda_3.set_seed(23u);
@@ -325,7 +317,7 @@ BOOST_AUTO_TEST_CASE(memory_test)
 BOOST_AUTO_TEST_CASE(integer_test_1)
 {
     population pop{minlp_rastrigin{3u, 3u}, 10u, 23u};
-    gaco uda{10u, 10u, 1.0, 1e9, 0.0, 5u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco uda{10u, 10u, 1.0, 1e9, 0.0, 5u, 7u, 1000u, 1000u, 0.0, false, 23u};
     uda.set_verbosity(1u);
     pop = uda.evolve(pop);
     for (decltype(pop.size()) i = 0u; i < pop.size(); ++i) {
@@ -337,7 +329,7 @@ BOOST_AUTO_TEST_CASE(integer_test_1)
 BOOST_AUTO_TEST_CASE(integer_test_2)
 {
     population pop{golomb_ruler{7, 10}, 10u, 23u};
-    gaco uda{10u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco uda{10u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, false, 23u};
     uda.set_verbosity(1u);
     pop = uda.evolve(pop);
     for (decltype(pop.size()) i = 0u; i < pop.size(); ++i) {
@@ -349,14 +341,14 @@ BOOST_AUTO_TEST_CASE(integer_test_2)
 BOOST_AUTO_TEST_CASE(bfe_usage_test)
 {
     population pop{rosenbrock{10u}, 200u, 23u};
-    gaco uda{40u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco uda{40u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, false, 23u};
     uda.set_verbosity(1u);
     uda.set_seed(23u);
     uda.set_bfe(bfe{}); // This will use the default bfe.
     pop = uda.evolve(pop);
 
     population pop_2{rosenbrock{10u}, 200u, 23u};
-    gaco uda_2{40u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, 10u, 0.9, false, 23u};
+    gaco uda_2{40u, 10u, 1.0, 25.0, 0.01, 5u, 7u, 1000u, 1000u, 0.0, false, 23u};
     uda_2.set_verbosity(1u);
     uda_2.set_seed(23u);
     pop_2 = uda_2.evolve(pop_2);


### PR DESCRIPTION
This PR aims to remove all the MO references in `gaco`, since it has been decided to do its MO extension in a separate algorithm (#326 ).