### PR TITLE
bug fix for PSO GEN

### DIFF
--- a/src/algorithms/pso_gen.cpp
+++ b/src/algorithms/pso_gen.cpp
@@ -441,7 +441,7 @@ population pso_gen::evolve(population pop) const
                         auto x2 = X[j];
                         double acc = 0.;
                         for (decltype(x1.size()) k = 0u; k < x1.size(); ++k) {
-                            if (ub[j] > lb[j]) {
+                            if (ub[k] > lb[k]) {
                                 acc += (x1[k] - x2[k]) * (x1[k] - x2[k]) / (ub[k] - lb[k]) / (ub[k] - lb[k]);
                             } // else 0
                         }

--- a/tests/pso_gen.cpp
+++ b/tests/pso_gen.cpp
@@ -289,3 +289,12 @@ BOOST_AUTO_TEST_CASE(serialization_test)
         BOOST_CHECK_CLOSE(std::get<5>(before_log[i]), std::get<5>(after_log[i]), 1e-8);
     }
 }
+
+BOOST_AUTO_TEST_CASE(bug)
+{
+    problem prob{rosenbrock{10u}};
+    population pop1{prob, 11u, 23u};
+    pso_gen user_algo1{10u, 0.79, 2., 2., 0.1, 1u, 1u, 4u, false, 23u};
+    user_algo1.set_verbosity(1u);
+    pop1 = user_algo1.evolve(pop1);
+}


### PR DESCRIPTION
This PR aims to fix a bug in the `pso_gen` algorithm.
Instead of
```
                        for (decltype(x1.size()) k = 0u; k < x1.size(); ++k) {
                            if (ub[j] > lb[j]) {
                                acc += (x1[k] - x2[k]) * (x1[k] - x2[k]) / (ub[k] - lb[k]) / (ub[k] - lb[k]);
                            } // else 0
                        }
```
it should be :
```
                        for (decltype(x1.size()) k = 0u; k < x1.size(); ++k) {
                            if (ub[k] > lb[k]) {
                                acc += (x1[k] - x2[k]) * (x1[k] - x2[k]) / (ub[k] - lb[k]) / (ub[k] - lb[k]);
                            } // else 0
                        }
```
As `j` spans through the `pop_size`, whereas `k` spans through the `dvs` size (which is the length of `ub`, `lb`).. This error was not spotted in the current tests because the `pop_size` were always chosen to be smaller than the `dvs` size.. thus shadowing the error.