### PR TITLE
[WIP] remove check for python3 component of boostfor boost>v1.7.1

### DIFF
--- a/cmake_modules/PagmoFindBoost.cmake
+++ b/cmake_modules/PagmoFindBoost.cmake
@@ -14,14 +14,14 @@ if(_PAGMO_FIND_BOOST_PYTHON)
     # NOTE: since Boost 1.67, the naming of the Boost.Python library has changed to include the
     # major and minor python version as a suffix. See the release notes:
     # https://www.boost.org/users/history/version_1_67_0.html
-    if(${Boost_MAJOR_VERSION} GREATER 1 OR (${Boost_MAJOR_VERSION} EQUAL 1 AND ${Boost_MINOR_VERSION} GREATER 66))
+    # Since Boost 1.71, specifiying major and minor python version is incorrect
+    # for specifying boost components
+    # https://www.boost.org/users/history/version_1_71_0.html
+    if(${Boost_MAJOR_VERSION} GREATER 1 OR (${Boost_MAJOR_VERSION} EQUAL 1 AND
+        ${Boost_MINOR_VERSION} GREATER 66 OR ${Boost_MINOR_VERSION} LESS 71))
         list(APPEND _PAGMO_REQUIRED_BOOST_LIBS "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
     else()
-        if(${PYTHON_VERSION_MAJOR} EQUAL 2)
-            list(APPEND _PAGMO_REQUIRED_BOOST_LIBS python)
-        else()
-            list(APPEND _PAGMO_REQUIRED_BOOST_LIBS python3)
-        endif()
+        list(APPEND _PAGMO_REQUIRED_BOOST_LIBS python)
     endif()
 endif()
 message(STATUS "Required Boost libraries: ${_PAGMO_REQUIRED_BOOST_LIBS}")


### PR DESCRIPTION
In the latest Boost version, they have changed how python components need to specified. Specifically, there is no need to specify major or minor version of python, Boost takes care of it internally. In fact, if you do specify a version that CMake will error out. As of now this is causing the `python-pygmo` package for ArchLinux to break.
Seems like there is another issue that I need to tackle before this PR is ready.