### PR TITLE
Turn TBB/NLopt/Ipopt into PRIVATE dependencies for libpagmo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ workflows:
   version: 2
   all_builds:
     jobs:
-    - bionic_gcc7_conda_py38
+    #- bionic_gcc7_conda_py38
     - bionic_gcc7_conda_py27
     - bionic_gcc7_coverage
     - cosmic_gcc8_asan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake version check.
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 # Module path setup.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules" "${CMAKE_SOURCE_DIR}/cmake_modules/yacma")
@@ -125,16 +125,12 @@ if(PAGMO_BUILD_PAGMO)
 
     # NLopt
     if(PAGMO_WITH_NLOPT)
-        find_package(NLOPT REQUIRED)
-        message(STATUS "NLopt include directory: ${NLOPT_INCLUDE_DIR}")
-        message(STATUS "NLopt library: ${NLOPT_LIBRARY}")
+        find_package(NLOPT REQUIRED COMPONENTS header libnlopt)
     endif()
 
     # Ipopt
     if(PAGMO_WITH_IPOPT)
-        find_package(IPOPT REQUIRED)
-        message(STATUS "Ipopt include directory: ${IPOPT_INCLUDE_DIR}")
-        message(STATUS "Ipopt library: ${IPOPT_LIBRARY}")
+        find_package(IPOPT REQUIRED COMPONENTS header libipopt)
     endif()
 
     if(PAGMO_BUILD_TESTS)
@@ -340,23 +336,25 @@ if(PAGMO_BUILD_PAGMO)
 
     if(PAGMO_WITH_NLOPT)
         # Link pagmo to NLopt.
-        # NOTE: although all the NLopt functions we use
-        # are called from within the .cpp files, we have
-        # to include a couple of NLopt headers in the
-        # public pagmo API. This, NLopt needs to be
-        # in the public link interface.
-        target_link_libraries(pagmo PUBLIC NLOPT::nlopt)
+        # NOTE: we make use of some NLopt types in the
+        # public pagmo interface, but we don't use any
+        # function from the library in the public headers.
+        # Thus, depend publicly on the header,
+        # privately on the compiled library.
+        target_link_libraries(pagmo PUBLIC NLOPT::header)
+        target_link_libraries(pagmo PRIVATE NLOPT::libnlopt)
         set(PAGMO_ENABLE_NLOPT "#define PAGMO_WITH_NLOPT")
     endif()
 
     if(PAGMO_WITH_IPOPT)
         # Link pagmo to Ipopt.
-        # NOTE: although all the Ipopt functions we use
-        # are called from within the .cpp files, we have
-        # to include a couple of Ipopt headers in the
-        # public pagmo API. This, Ipopt needs to be
-        # in the public link interface.
-        target_link_libraries(pagmo PUBLIC IPOPT::ipopt)
+        # NOTE: we make use of some Ipopt types in the
+        # public pagmo interface, but we don't use any
+        # function from the library in the public headers.
+        # Thus, depend publicly on the header,
+        # privately on the compiled library.
+        target_link_libraries(pagmo PUBLIC IPOPT::header)
+        target_link_libraries(pagmo PRIVATE IPOPT::libipopt)
         set(PAGMO_ENABLE_IPOPT "#define PAGMO_WITH_IPOPT")
     endif()
 
@@ -426,10 +424,10 @@ if(PAGMO_BUILD_PAGMO)
         set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(Eigen3 REQUIRED)\n")
     endif()
     if(PAGMO_WITH_NLOPT)
-        set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(NLOPT REQUIRED)\n")
+        set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(NLOPT REQUIRED COMPONENTS header)\n")
     endif()
     if(PAGMO_WITH_IPOPT)
-        set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(IPOPT REQUIRED)\n")
+        set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(IPOPT REQUIRED COMPONENTS header)\n")
     endif()
 
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pagmo-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/pagmo-config.cmake" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,10 @@ if(PAGMO_BUILD_PAGMO)
     target_link_libraries(pagmo PUBLIC Boost::boost Boost::serialization)
 
     # TBB.
-    target_link_libraries(pagmo PUBLIC TBB::tbb)
+    # NOTE: TBB is a private dependency because
+    # all uses of TBB are limited to the .cpp files,
+    # thus fully encapsulated in the pagmo library.
+    target_link_libraries(pagmo PRIVATE TBB::tbb)
 
     if(PAGMO_WITH_EIGEN3)
         # Link pagmo to eigen3.
@@ -337,12 +340,22 @@ if(PAGMO_BUILD_PAGMO)
 
     if(PAGMO_WITH_NLOPT)
         # Link pagmo to NLopt.
+        # NOTE: although all the NLopt functions we use
+        # are called from within the .cpp files, we have
+        # to include a couple of NLopt headers in the
+        # public pagmo API. This, NLopt needs to be
+        # in the public link interface.
         target_link_libraries(pagmo PUBLIC NLOPT::nlopt)
         set(PAGMO_ENABLE_NLOPT "#define PAGMO_WITH_NLOPT")
     endif()
 
     if(PAGMO_WITH_IPOPT)
         # Link pagmo to Ipopt.
+        # NOTE: although all the Ipopt functions we use
+        # are called from within the .cpp files, we have
+        # to include a couple of Ipopt headers in the
+        # public pagmo API. This, Ipopt needs to be
+        # in the public link interface.
         target_link_libraries(pagmo PUBLIC IPOPT::ipopt)
         set(PAGMO_ENABLE_IPOPT "#define PAGMO_WITH_IPOPT")
     endif()
@@ -423,7 +436,7 @@ if(PAGMO_BUILD_PAGMO)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pagmo-config.cmake" DESTINATION "lib/cmake/pagmo")
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindEigen3.cmake" "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindNLOPT.cmake"
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindIPOPT.cmake" "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/PagmoFindBoost.cmake"
-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindTBB.cmake" DESTINATION "lib/cmake/pagmo")
+        DESTINATION "lib/cmake/pagmo")
     install(EXPORT pagmo_export NAMESPACE Pagmo:: DESTINATION lib/cmake/pagmo)
     # Take care of versioning.
     include(CMakePackageConfigHelpers)

--- a/ap_examples/uda_basic/CMakeLists.txt
+++ b/ap_examples/uda_basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 project(uda_basic)
 

--- a/ap_examples/udp_basic/CMakeLists.txt
+++ b/ap_examples/udp_basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 project(udp_basic)
 

--- a/cmake_modules/FindIPOPT.cmake
+++ b/cmake_modules/FindIPOPT.cmake
@@ -1,20 +1,57 @@
-if(IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
-	# Already in cache, be silent
-	set(IPOPT_FIND_QUIETLY TRUE)
-endif()
-
-find_path(IPOPT_INCLUDE_DIR NAMES IpIpoptNLP.hpp PATH_SUFFIXES coin)
-find_library(IPOPT_LIBRARY NAMES ipopt)
-
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(IPOPT DEFAULT_MSG IPOPT_INCLUDE_DIR IPOPT_LIBRARY)
+message(STATUS "Requested IPOPT components: ${IPOPT_FIND_COMPONENTS}")
 
-mark_as_advanced(IPOPT_INCLUDE_DIR IPOPT_LIBRARY)
+# Check the components that were passed to find_package().
+set(_IPOPT_ALLOWED_COMPONENTS header libipopt)
+foreach(_IPOPT_CUR_COMPONENT ${IPOPT_FIND_COMPONENTS})
+    if(NOT ${_IPOPT_CUR_COMPONENT} IN_LIST _IPOPT_ALLOWED_COMPONENTS)
+        message(FATAL_ERROR "'${_IPOPT_CUR_COMPONENT}' is not a valid component for IPOPT.")
+    endif()
+endforeach()
+unset(_IPOPT_ALLOWED_COMPONENTS)
 
-# NOTE: this has been adapted from CMake's FindPNG.cmake.
-if(IPOPT_FOUND AND NOT TARGET IPOPT::ipopt)
-    add_library(IPOPT::ipopt UNKNOWN IMPORTED)
-    set_target_properties(IPOPT::ipopt PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${IPOPT_INCLUDE_DIR}")
-    set_target_properties(IPOPT::ipopt PROPERTIES IMPORTED_LOCATION "${IPOPT_LIBRARY}")
+# Setup the list of arguments to be passed to
+# find_package_handle_standard_args().
+set(_IPOPT_FPHSA_ARGS)
+
+if ("header" IN_LIST IPOPT_FIND_COMPONENTS)
+    # The header component was requested.
+    # The associated variable is IPOPT_INCLUDE_DIR.
+    list(APPEND _IPOPT_FPHSA_ARGS IPOPT_INCLUDE_DIR)
+    find_path(IPOPT_INCLUDE_DIR NAMES IpIpoptNLP.hpp PATH_SUFFIXES coin)
+endif()
+
+if ("libipopt" IN_LIST IPOPT_FIND_COMPONENTS)
+    # The libipopt component was requested.
+    # The associated variable is IPOPT_LIBRARY.
+    list(APPEND _IPOPT_FPHSA_ARGS IPOPT_LIBRARY)
+    find_library(IPOPT_LIBRARY NAMES ipopt)
+endif()
+
+# Run the standard find_package() machinery.
+find_package_handle_standard_args(IPOPT DEFAULT_MSG ${_IPOPT_FPHSA_ARGS})
+unset(_IPOPT_FPHSA_ARGS)
+
+if("header" IN_LIST IPOPT_FIND_COMPONENTS)
+    mark_as_advanced(IPOPT_INCLUDE_DIR)
+
+    if(IPOPT_FOUND AND NOT TARGET IPOPT::header)
+        message(STATUS "Creating the 'IPOPT::header' imported target.")
+        add_library(IPOPT::header INTERFACE IMPORTED)
+        message(STATUS "Path to the ipopt headers: ${IPOPT_INCLUDE_DIR}")
+        set_target_properties(IPOPT::header PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${IPOPT_INCLUDE_DIR}")
+    endif()
+endif()
+
+if ("libipopt" IN_LIST IPOPT_FIND_COMPONENTS)
+    mark_as_advanced(IPOPT_LIBRARY)
+
+    if(IPOPT_FOUND AND NOT TARGET IPOPT::libipopt)
+        message(STATUS "Creating the 'IPOPT::libipopt' imported target.")
+        # Otherwise, we proceed as usual.
+        message(STATUS "Path to libipopt: ${IPOPT_LIBRARY}")
+        add_library(IPOPT::libipopt UNKNOWN IMPORTED)
+        set_target_properties(IPOPT::libipopt PROPERTIES IMPORTED_LOCATION "${IPOPT_LIBRARY}")
+    endif()
 endif()

--- a/cmake_modules/FindNLOPT.cmake
+++ b/cmake_modules/FindNLOPT.cmake
@@ -1,21 +1,59 @@
-if(NLOPT_INCLUDE_DIR AND NLOPT_LIBRARY)
-	# Already in cache, be silent
-	set(NLOPT_FIND_QUIETLY TRUE)
-endif()
-
-find_path(NLOPT_INCLUDE_DIR NAMES nlopt.h)
-find_library(NLOPT_LIBRARY NAMES nlopt)
-
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(NLOPT DEFAULT_MSG NLOPT_INCLUDE_DIR NLOPT_LIBRARY)
+message(STATUS "Requested NLOPT components: ${NLOPT_FIND_COMPONENTS}")
 
-mark_as_advanced(NLOPT_INCLUDE_DIR NLOPT_LIBRARY)
+# Check the components that were passed to find_package().
+set(_NLOPT_ALLOWED_COMPONENTS header libnlopt)
+foreach(_NLOPT_CUR_COMPONENT ${NLOPT_FIND_COMPONENTS})
+    if(NOT ${_NLOPT_CUR_COMPONENT} IN_LIST _NLOPT_ALLOWED_COMPONENTS)
+        message(FATAL_ERROR "'${_NLOPT_CUR_COMPONENT}' is not a valid component for NLOPT.")
+    endif()
+endforeach()
+unset(_NLOPT_ALLOWED_COMPONENTS)
 
-# NOTE: this has been adapted from CMake's FindPNG.cmake.
-if(NLOPT_FOUND AND NOT TARGET NLOPT::nlopt)
-    add_library(NLOPT::nlopt UNKNOWN IMPORTED)
-    set_target_properties(NLOPT::nlopt PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${NLOPT_INCLUDE_DIR}")
-    set_target_properties(NLOPT::nlopt PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-        IMPORTED_LOCATION "${NLOPT_LIBRARY}")
+# Setup the list of arguments to be passed to
+# find_package_handle_standard_args().
+set(_NLOPT_FPHSA_ARGS)
+
+if ("header" IN_LIST NLOPT_FIND_COMPONENTS)
+    # The header component was requested.
+    # The associated variable is NLOPT_INCLUDE_DIR.
+    list(APPEND _NLOPT_FPHSA_ARGS NLOPT_INCLUDE_DIR)
+    find_path(NLOPT_INCLUDE_DIR NAMES nlopt.h)
+endif()
+
+if ("libnlopt" IN_LIST NLOPT_FIND_COMPONENTS)
+    # The libnlopt component was requested.
+    # The associated variable is NLOPT_LIBRARY.
+    list(APPEND _NLOPT_FPHSA_ARGS NLOPT_LIBRARY)
+    find_library(NLOPT_LIBRARY NAMES nlopt)
+endif()
+
+# Run the standard find_package() machinery.
+find_package_handle_standard_args(NLOPT DEFAULT_MSG ${_NLOPT_FPHSA_ARGS})
+unset(_NLOPT_FPHSA_ARGS)
+
+if("header" IN_LIST NLOPT_FIND_COMPONENTS)
+    mark_as_advanced(NLOPT_INCLUDE_DIR)
+
+    if(NLOPT_FOUND AND NOT TARGET NLOPT::header)
+        message(STATUS "Creating the 'NLOPT::header' imported target.")
+        add_library(NLOPT::header INTERFACE IMPORTED)
+        message(STATUS "Path to the nlopt.h header: ${NLOPT_INCLUDE_DIR}")
+        set_target_properties(NLOPT::header PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${NLOPT_INCLUDE_DIR}")
+    endif()
+endif()
+
+if ("libnlopt" IN_LIST NLOPT_FIND_COMPONENTS)
+    mark_as_advanced(NLOPT_LIBRARY)
+
+    if(NLOPT_FOUND AND NOT TARGET NLOPT::libnlopt)
+        message(STATUS "Creating the 'NLOPT::libnlopt' imported target.")
+        # Otherwise, we proceed as usual.
+        message(STATUS "Path to libnlopt: ${NLOPT_LIBRARY}")
+        add_library(NLOPT::libnlopt UNKNOWN IMPORTED)
+        set_target_properties(NLOPT::libnlopt PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${NLOPT_LIBRARY}")
+    endif()
 endif()

--- a/pagmo-config.cmake.in
+++ b/pagmo-config.cmake.in
@@ -7,7 +7,6 @@ list(APPEND CMAKE_MODULE_PATH "${_PAGMO_CONFIG_SELF_DIR}")
 set(THREADS_PREFER_PTHREAD_FLAG YES)
 find_package(Threads REQUIRED)
 unset(THREADS_PREFER_PTHREAD_FLAG)
-find_package(TBB REQUIRED)
 include(PagmoFindBoost)
 @_PAGMO_CONFIG_OPTIONAL_DEPS@
 # Restore original module path.

--- a/tools/circleci_bionic_gcc7_conda_py38.sh
+++ b/tools/circleci_bionic_gcc7_conda_py38.sh
@@ -10,7 +10,7 @@ set -e
 sudo apt-get install build-essential wget
 
 # Install conda+deps.
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.sh
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 export deps_dir=$HOME/local
 export PATH="$HOME/miniconda/bin:$PATH"
 export PATH="$deps_dir/bin:$PATH"

--- a/tools/circleci_bionic_gcc7_conda_py38.sh
+++ b/tools/circleci_bionic_gcc7_conda_py38.sh
@@ -10,7 +10,7 @@ set -e
 sudo apt-get install build-essential wget
 
 # Install conda+deps.
-wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.sh
 export deps_dir=$HOME/local
 export PATH="$HOME/miniconda/bin:$PATH"
 export PATH="$deps_dir/bin:$PATH"


### PR DESCRIPTION
I just noticed that all the uses we make of TBB are encapsulated within the cpp files (thus, within the ``libpagmo.so`` binary), but TBB is linked as a ``PUBLIC`` dependency for pagmo in the CMake machinery.

This means that a package linking to ``Pagmo::pagmo`` (e.g., pygmo or pagmo_plugins_nonfree) will link to TBB, but this is not really needed as there is nothing from TBB in the public pagmo API: TBB will be brought into the link chain indirectly by ``libpagmo.so``, which is the only entity (in this scenario) making use of the TBB API.

(Note that, if we had, for instance, a function template or just an inline function somewhere making use of some TBB functionality - like ``parallel_for`` - then we would have to add TBB back as a ``PUBLIC`` dependency)

Similarly, regarding NLopt and Ipopt, we have a public dependency only on their headers via some type definitions, but we can actually depend privately on the compiled libraries.