### PR TITLE
Fail fast Pareto dominance

### DIFF
--- a/src/utils/multi_objective.cpp
+++ b/src/utils/multi_objective.cpp
@@ -101,16 +101,17 @@ bool pareto_dominance(const vector_double &obj1, const vector_double &obj2)
                     "Different number of objectives found in input fitnesses: " + std::to_string(obj1.size()) + " and "
                         + std::to_string(obj2.size()) + ". I cannot define dominance");
     }
-    vector_double::size_type count1 = 0, count2 = 0;
+    bool foundStrictlyDominatingDimension = false;
     for (decltype(obj1.size()) i = 0u; i < obj1.size(); ++i) {
         if (detail::less_than_f(obj1[i], obj2[i])) {
-            ++count1;
-        }
-        if (detail::equal_to_f(obj1[i], obj2[i])) {
-            ++count2;
+            foundStrictlyDominatingDimension = true;
+        } else if (detail::equal_to_f(obj1[i], obj2[i])) {
+            continue;
+        } else {
+            return false;
         }
     }
-    return (((count1 + count2) == obj1.size()) && (count1 > 0u));
+    return foundStrictlyDominatingDimension;
 }
 
 /// Non dominated front 2D (Kung's algorithm)


### PR DESCRIPTION
## Description
- If we find a dimension which precludes dominance, then return `false` early
-----
## Results
Failing fast in this way yielded a ~30% speedup of this method in my program. `perf` data:
- Previous - 20.0% samples had `pareto_dominance` in the call stack
- Modified - 13.5% samples had `pareto_dominance` in the call stack
----
## Possible issues
- More performance could still possibly be squeezed out by re-arranging the order in which the comparisons are performed inside the loop
- I haven't had chance to test on a diverse range of problems