### PR TITLE
Move the BFE fevals counting into the pagmo::bfe class.

### DIFF
--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -14,6 +14,17 @@ New
   `website <https://github.com/esa/pygmo2>`__
   for pygmo's documentation and changelog.
 
+- Implement a setter for the migration database
+  of an archipelago
+  (`#390 <https://github.com/esa/pagmo2/pull/390>`__).
+
+Changes
+~~~~~~~
+
+- Various performance improvements for the
+  Pareto dominance utilities
+  (`#394 <https://github.com/esa/pagmo2/pull/394>`__).
+
 2.13.0 (2020-01-10)
 -------------------
 

--- a/doc/sphinx/docs/cpp/batch_evaluators/thread_bfe.rst
+++ b/doc/sphinx/docs/cpp/batch_evaluators/thread_bfe.rst
@@ -14,7 +14,7 @@ Multithreaded BFE
    :cpp:class:`~pagmo::thread_bfe` will use multiple threads of execution to parallelise
    the evaluation of the fitnesses of a batch of input decision vectors.
 
-   .. cpp:function:: vector_double operator()(const problem &p, const vector_double &dvs) const
+   .. cpp:function:: vector_double operator()(problem p, const vector_double &dvs) const
 
       Call operator.
 

--- a/doc/sphinx/docs/cpp/bfe.rst
+++ b/doc/sphinx/docs/cpp/bfe.rst
@@ -169,6 +169,7 @@ Batch fitness evaluator
       will occupy the range :math:`\left[f, 2f\right)`, and so on.
 
       This function will perform a variety of sanity checks on both *dvs* and on the return value.
+      It will also take care of increasing the fitness evaluation counter in *p*.
 
       :param p: the input :cpp:class:`~pagmo::problem`.
       :param dvs: the input decision vectors that will be evaluated in batch mode.

--- a/include/pagmo/batch_evaluators/thread_bfe.hpp
+++ b/include/pagmo/batch_evaluators/thread_bfe.hpp
@@ -44,7 +44,10 @@ class PAGMO_DLL_PUBLIC thread_bfe
 {
 public:
     // Call operator.
-    vector_double operator()(const problem &, const vector_double &) const;
+    // NOTE: pass the problem by copy, as we want to ensure the
+    // fitness() of the original problem is never called in order
+    // to avoid altering the fevals counter.
+    vector_double operator()(problem, const vector_double &) const;
     // Name.
     std::string get_name() const
     {

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -954,7 +954,7 @@ namespace detail
 // them as free functions.
 PAGMO_DLL_PUBLIC void prob_check_dv(const problem &, const double *, vector_double::size_type);
 PAGMO_DLL_PUBLIC void prob_check_fv(const problem &, const double *, vector_double::size_type);
-PAGMO_DLL_PUBLIC vector_double prob_invoke_mem_batch_fitness(const problem &, const vector_double &);
+PAGMO_DLL_PUBLIC vector_double prob_invoke_mem_batch_fitness(const problem &, const vector_double &, bool);
 
 } // namespace detail
 
@@ -1206,7 +1206,8 @@ public:
 private:
 #if !defined(PAGMO_DOXYGEN_INVOKED)
     // Make friends with the batch_fitness() invocation helper.
-    friend PAGMO_DLL_PUBLIC vector_double detail::prob_invoke_mem_batch_fitness(const problem &, const vector_double &);
+    friend PAGMO_DLL_PUBLIC vector_double detail::prob_invoke_mem_batch_fitness(const problem &, const vector_double &,
+                                                                                bool);
 #endif
 
 public:

--- a/src/batch_evaluators/member_bfe.cpp
+++ b/src/batch_evaluators/member_bfe.cpp
@@ -39,7 +39,9 @@ namespace pagmo
 // Call operator.
 vector_double member_bfe::operator()(const problem &p, const vector_double &dvs) const
 {
-    return detail::prob_invoke_mem_batch_fitness(p, dvs);
+    // NOTE: do *not* increment the fevals, as this is taken
+    // care of by pagmo::bfe.
+    return detail::prob_invoke_mem_batch_fitness(p, dvs, false);
 }
 
 // Serialization support.

--- a/src/batch_evaluators/thread_bfe.cpp
+++ b/src/batch_evaluators/thread_bfe.cpp
@@ -32,8 +32,6 @@ see https://www.gnu.org/licenses/. */
 #include <limits>
 #include <stdexcept>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 
@@ -49,7 +47,7 @@ namespace pagmo
 {
 
 // Call operator.
-vector_double thread_bfe::operator()(const problem &p, const vector_double &dvs) const
+vector_double thread_bfe::operator()(problem p, const vector_double &dvs) const
 {
     // Fetch a few quantities from the problem.
     // Problem dimension.
@@ -123,9 +121,6 @@ vector_double thread_bfe::operator()(const problem &p, const vector_double &dvs)
         tbb::parallel_for(range_t(0u, n_dvs), [p, &range_evaluator](const range_t &range) {
             range_evaluator(p, range.begin(), range.end());
         });
-        // Manually increment the fitness eval counter in p. Since we used copies
-        // of p for the parallel fitness evaluations, the counter in p did not change.
-        p.increment_fevals(boost::numeric_cast<unsigned long long>(n_dvs));
     } else {
         pagmo_throw(std::invalid_argument, "Cannot use a thread_bfe on the problem '" + p.get_name()
                                                + "', which does not provide the required level of thread safety");

--- a/src/bfe.cpp
+++ b/src/bfe.cpp
@@ -30,6 +30,8 @@ see https://www.gnu.org/licenses/. */
 #include <string>
 #include <utility>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <pagmo/batch_evaluators/default_bfe.hpp>
 #include <pagmo/bfe.hpp>
 #include <pagmo/detail/bfe_impl.hpp>
@@ -88,10 +90,20 @@ vector_double bfe::operator()(const problem &p, const vector_double &dvs) const
 {
     // Check the input dvs.
     detail::bfe_check_input_dvs(p, dvs);
+
     // Invoke the call operator from the UDBFE.
     auto retval((*ptr())(p, dvs));
+
     // Check the produced vector of fitnesses.
     detail::bfe_check_output_fvs(p, dvs, retval);
+
+    // Update the fevals counter in p.
+    // NOTE: we already checked in bfe_check_input_dvs()
+    // that the problem dimension exactly divides
+    // dvs.size().
+    const auto n_dvs = dvs.size() / p.get_nx();
+    p.increment_fevals(boost::numeric_cast<unsigned long long>(n_dvs));
+
     return retval;
 }
 

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -415,7 +415,7 @@ vector_double problem::batch_fitness(const vector_double &dvs) const
 
     // Invoke the batch fitness function of the UDP, and
     // increase the fevals counter as well.
-    auto retval = detail::prob_invoke_mem_batch_fitness(*this, dvs);
+    auto retval = detail::prob_invoke_mem_batch_fitness(*this, dvs, true);
 
     // Check the produced vector of fitnesses.
     detail::bfe_check_output_fvs(*this, dvs, retval);
@@ -938,14 +938,17 @@ void prob_check_fv(const problem &p, const double *fv, vector_double::size_type 
 // This is useful for avoiding doing double checks on the input/output values
 // of batch_fitness() when we are sure that the checks have been performed elsewhere already.
 // This helper will also take care of increasing the fevals counter in the
-// input problem.
-vector_double prob_invoke_mem_batch_fitness(const problem &p, const vector_double &dvs)
+// input problem, if requested.
+vector_double prob_invoke_mem_batch_fitness(const problem &p, const vector_double &dvs, bool incr_fevals)
 {
     // Invoke the batch fitness from the UDP.
     auto retval(p.ptr()->batch_fitness(dvs));
 
-    // Increment the number of fitness evaluations.
-    p.increment_fevals(boost::numeric_cast<unsigned long long>(dvs.size() / p.get_nx()));
+    // Increment the number of fitness evaluations, if
+    // requested.
+    if (incr_fevals) {
+        p.increment_fevals(boost::numeric_cast<unsigned long long>(dvs.size() / p.get_nx()));
+    }
 
     return retval;
 }

--- a/src/problems/translate.cpp
+++ b/src/problems/translate.cpp
@@ -133,7 +133,7 @@ vector_double translate::batch_fitness(const vector_double &xs) const
     // or of the fitness, thus all the checks run by m_problem.batch_fitness()
     // are redundant.
 #if defined(NDEBUG)
-    return detail::prob_invoke_mem_batch_fitness(m_problem, xs_deshifted);
+    return detail::prob_invoke_mem_batch_fitness(m_problem, xs_deshifted, true);
 #else
     return m_problem.batch_fitness(xs_deshifted);
 #endif


### PR DESCRIPTION
This PR moves the fevals counting mechanism from the UDBFEs into the ``pagmo::bfe`` class, so that all UDBFEs now automatically take advantage of it. This change should make the counting of fevals consistent across different UDBFEs.