### PR TITLE
New implementation for push_back into the population

### DIFF
--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -38,6 +38,10 @@ Changes
 Fix
 ~~~
 
+- Avoid quadratic complexity
+  in :cpp:func:`pagmo::population::push_back()`
+  (`#434 <https://github.com/esa/pagmo2/pull/434>`__).
+
 - Fix build with recent Ipopt versions
   (`#412 <https://github.com/esa/pagmo2/pull/412>`__).
 

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -593,20 +593,20 @@ void population::push_back_impl(T &&x, U &&f)
     auto x_copy(std::forward<T>(x));
     auto f_copy(std::forward<U>(f));
 
-    // Here we make sure that if the push back is unsuccesfull, the population state is left unchanged.
-    auto n = pop.size();
+    // Here we make sure that if the push back is unsuccessfull, the population state is left unchanged.
+    auto n = m_ID.size();
     try {
         m_ID.push_back(new_id);
         m_x.push_back(std::move(x_copy));
         m_f.push_back(std::move(f_copy));
         // update_champion() either throws before modifying anything, or it completes successfully.
-        update_champion(pop.get_x(n+1), pop.get_f(n+1));
+        update_champion(m_x.back(), m_f.back());
     } catch (...) {
         m_ID.resize(n);
         m_x.resize(n);
         m_f.resize(n);
+        throw;
     }
-    
 }
 
 // Short routine to update the champion. Does nothing if the problem is MO

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -593,18 +593,20 @@ void population::push_back_impl(T &&x, U &&f)
     auto x_copy(std::forward<T>(x));
     auto f_copy(std::forward<U>(f));
 
+    // Here we make sure that if the push back is unsuccesfull, the population state is left unchanged.
     auto n = pop.size();
     try {
         m_ID.push_back(new_id);
         m_x.push_back(std::move(x_copy));
         m_f.push_back(std::move(f_copy));
+        // update_champion() either throws before modifying anything, or it completes successfully.
+        update_champion(pop.get_x(n+1), pop.get_f(n+1));
     } catch (...) {
         m_ID.resize(n);
         m_x.resize(n);
         m_f.resize(n);
     }
-    // update_champion() either throws before modfying anything, or it completes successfully. The rest is noexcept.
-    update_champion(pop.get_x(n+1), pop.get_f(n+1));
+    
 }
 
 // Short routine to update the champion. Does nothing if the problem is MO

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -593,8 +593,8 @@ void population::push_back_impl(T &&x, U &&f)
     auto x_copy(std::forward<T>(x));
     auto f_copy(std::forward<U>(f));
 
-    // Here we make sure that if the push back is unsuccessfull, the population state is left unchanged.
-    auto n = m_ID.size();
+    // Here we make sure that if the push back is unsuccessful, the population state is left unchanged.
+    const auto n = m_ID.size();
     try {
         m_ID.push_back(new_id);
         m_x.push_back(std::move(x_copy));

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -592,16 +592,21 @@ void population::push_back_impl(T &&x, U &&f)
     const auto new_id = std::uniform_int_distribution<unsigned long long>()(m_e);
     auto x_copy(std::forward<T>(x));
     auto f_copy(std::forward<U>(f));
-    // Reserve space in the vectors.
-    m_ID.reserve(m_ID.size() + 1u);
-    m_x.reserve(m_x.size() + 1u);
-    m_f.reserve(m_f.size() + 1u);
 
     // update_champion() either throws before modfying anything, or it completes successfully. The rest is noexcept.
     update_champion(x_copy, f_copy);
-    m_ID.push_back(new_id);
-    m_x.push_back(std::move(x_copy));
-    m_f.push_back(std::move(f_copy));
+    try {
+        m_ID.push_back(new_id);
+        m_x.push_back(std::move(x_copy));
+        m_f.push_back(std::move(f_copy));
+    } catch (...) {
+        auto n = m_ID.size();
+        n = std::min(n, m_x.size());
+        n = std::min(n, m_f.size());
+        m_ID.resize(n);
+        m_x.resize(n);
+        m_f.resize(n);
+    }
 }
 
 // Short routine to update the champion. Does nothing if the problem is MO

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -593,20 +593,18 @@ void population::push_back_impl(T &&x, U &&f)
     auto x_copy(std::forward<T>(x));
     auto f_copy(std::forward<U>(f));
 
-    // update_champion() either throws before modfying anything, or it completes successfully. The rest is noexcept.
-    update_champion(x_copy, f_copy);
+    auto n = pop.size();
     try {
         m_ID.push_back(new_id);
         m_x.push_back(std::move(x_copy));
         m_f.push_back(std::move(f_copy));
     } catch (...) {
-        auto n = m_ID.size();
-        n = std::min(n, m_x.size());
-        n = std::min(n, m_f.size());
         m_ID.resize(n);
         m_x.resize(n);
         m_f.resize(n);
     }
+    // update_champion() either throws before modfying anything, or it completes successfully. The rest is noexcept.
+    update_champion(pop.get_x(n+1), pop.get_f(n+1));
 }
 
 // Short routine to update the champion. Does nothing if the problem is MO


### PR DESCRIPTION
Complexity should now be O(n) rather than O(n^2). So creatinon of large populations is also dominated by the fitness computation rather than book-keeping overheads.