### PR TITLE
Updating grey wolf optimizer

### DIFF
--- a/src/algorithms/gwo.cpp
+++ b/src/algorithms/gwo.cpp
@@ -167,11 +167,17 @@ population gwo::evolve(population pop) const
             auto fit = pop.get_f()[i];
             // Update alpha, beta and delta
             if (fit[0] < alpha_score) {
+                delta_score = beta_score;
+                delta_pos = beta_pos;
+                beta_score = alpha_score;
+                beta_pos = alpha_pos;
                 alpha_score = fit[0];
                 alpha_pos = agents_position[i];
             }
 
             if (fit[0] > alpha_score && fit[0] < beta_score) {
+                delta_score = beta_score;
+                delta_pos = beta_pos;
                 beta_score = fit[0];
                 beta_pos = agents_position[i];
             }


### PR DESCRIPTION
There was a [problem](https://github.com/7ossam81/EvoloPy/issues/21) in the code implemented before in [EvoloPy](https://github.com/7ossam81/EvoloPy), the code which pagmo's GWO implementation was based on intially, this mistake originates from the [matlab function](https://www.mathworks.com/matlabcentral/fileexchange/44974-grey-wolf-optimizer-gwo) purposed in the original paper.  The author confirmed in mathworks comment section (in 2014) that this should be corrected.

The _actual_ position updating has no issue but the best scores/positions logged for each iteration isn't updating the three values (Alpha, Beta and Delta) it was only one of the three only when the best of current generation is better than the value the tier x holds right now.

Example: 
```
A: 1  B: 1.9  D: 2.3
Next iter Best 3 are:  0.9        1.1           2.5
A: 0.9 B: 1.1   D: 2.3
```
While the correct values should be
`A: 0.9 B: 1.1   D: 1.9`


The original GWO PR is #268. I took a look at it and learned about exposing the code to pygmo, so I compiled pagmo and installed pygmo from the source and re-generated the [comparison](https://gist.github.com/michiboo/2df766cd7f59c0eb579290c8cbf2536e) made in the original PR to show how different the two approaches are. And it shows slight noticeable difference.

current GWO:
![OLDALL](https://user-images.githubusercontent.com/26524089/83332836-b9439280-a29d-11ea-86d2-a46d06e0078e.png)

After updating:
![NEW_ALL COMP](https://user-images.githubusercontent.com/26524089/83332840-c06aa080-a29d-11ea-821e-7db4f44cdf9f.png)


I didn't change much of the code, I don't think any tests should be refactored from this change.