### PR TITLE
added genetic_operators.hpp to include list in pagmo.hpp

### DIFF
--- a/include/pagmo/pagmo.hpp
+++ b/include/pagmo/pagmo.hpp
@@ -62,6 +62,7 @@ see https://www.gnu.org/licenses/. */
 #include <pagmo/utils/hv_algos/hv_hvwfg.hpp>
 #include <pagmo/utils/hypervolume.hpp>
 #include <pagmo/utils/multi_objective.hpp>
+#include <pagmo/utils/genetic_operators.hpp>
 
 // Algorithms.
 #include <pagmo/algorithms/bee_colony.hpp>


### PR DESCRIPTION
This causes it to be installed by CMake.
Without this, it will, at least on my Ubuntu 18.04. not end up being installed and not found by the current master of pygmo, which looks for it when the pagmo version is newer than 2.15.