### PR TITLE
don't force static runtime for static lib if msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,27 +151,6 @@ endif()
 # Boost setup.
 include(PagmoFindBoost)
 
-# Explanation: on MSVC, when building static libraries, it is good practice to link
-# to the static runtime. CMake, however, is hard-coded to link to the dynamic runtime.
-# Hence we hackishly replace the /MD flag with /MT. This is the approach suggested
-# in the CMake FAQ:
-#
-# https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-build-my-msvc-application-with-a-static-runtime
-#
-# Note that at one point CMake added the possiblity to set this as a target property,
-# so in the future we should definitely migrate to that approach:
-#
-# https://cmake.org/cmake/help/git-master/prop_tgt/MSVC_RUNTIME_LIBRARY.html
-if(YACMA_COMPILER_IS_MSVC AND PAGMO_BUILD_STATIC_LIBRARY)
-    foreach(flag_var
-            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if(${flag_var} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif()
-    endforeach()
-endif()
-
 # List of source files.
 set(PAGMO_SRC_FILES
     # Core classes.


### PR DESCRIPTION
It is not "good practice to link to static runtime", quite the opposite actually. It's not bad to link to static runtime, but it's bad practice to force this behavior in a library since consumers must link all their static dependencies with the same runtime (which is /MD by default).
Moreover it defeats principle of least surprise.

conan & vcpkg remove this block:
- https://github.com/conan-io/conan-center-index/blob/f2542cd56c3483a604fe32b68022f6ab26996eef/recipes/pagmo2/all/conanfile.py#L98-L101
- https://github.com/microsoft/vcpkg/blob/7c55ecac266fc3e554bc315053dc45c11ec811af/ports/pagmo2/disable-md-override.patch

Another solution is to add a CMake option to select the runtime, but it's usually useless and confusing, since consumers usually inject their runtime through `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` in cmake command line in a consistent way for all their dependencies.