### PR TITLE
gaco bugfix: throw if ker < 2

### DIFF
--- a/include/pagmo/algorithms/gaco.hpp
+++ b/include/pagmo/algorithms/gaco.hpp
@@ -115,7 +115,7 @@ public:
      *
      * @throws std::invalid_argument if \p acc is not \f$ >=0 \f$, \p impstop is not a
      * positive integer, \p evalstop is not a positive integer, \p focus is not \f$ >=0 \f$,
-     * \p ker is not a positive integer, \p oracle is not positive, \p
+     * \p ker is not a positive integer \in [2, pop_size], \p oracle is not positive, \p
      * threshold is not \f$ \in [1,gen] \f$ when \f$memory=false\f$ and  \f$gen!=0\f$, \p threshold is not \f$ >=1 \f$
      * when \f$memory=true\f$ and \f$gen!=0\f$, \p q is not \f$ >=0 \f$
      */

--- a/include/pagmo/algorithms/gaco.hpp
+++ b/include/pagmo/algorithms/gaco.hpp
@@ -115,7 +115,7 @@ public:
      *
      * @throws std::invalid_argument if \p acc is not \f$ >=0 \f$, \p impstop is not a
      * positive integer, \p evalstop is not a positive integer, \p focus is not \f$ >=0 \f$,
-     * \p ker is not a positive integer \in [2, pop_size], \p oracle is not positive, \p
+     * \p ker is not \f$ >=2 \f$, \p oracle is not positive, \p
      * threshold is not \f$ \in [1,gen] \f$ when \f$memory=false\f$ and  \f$gen!=0\f$, \p threshold is not \f$ >=1 \f$
      * when \f$memory=true\f$ and \f$gen!=0\f$, \p q is not \f$ >=0 \f$
      */

--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -149,9 +149,9 @@ population gaco::evolve(population pop) const
         return pop;
     }
     // I verify that the solution archive is smaller or equal than the population size
-    if (m_ker > pop_size) {
+    if (m_ker > pop_size || m_ker < 2) {
         pagmo_throw(std::invalid_argument,
-                    get_name() + " cannot work with a solution archive bigger than the population size");
+                    get_name() + " cannot work with a solution archive bigger than the population size or smaller than 2");
     }
     if (n_obj != 1u) {
         pagmo_throw(std::invalid_argument, "Multiple objectives detected in " + prob.get_name() + " instance. "

--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -85,6 +85,10 @@ gaco::gaco(unsigned gen, unsigned ker, double q, double oracle, double acc, unsi
         pagmo_throw(std::invalid_argument, "The convergence speed parameter must be >=0  while a value of "
                                                + std::to_string(q) + " was detected");
     }
+    if (ker < 2u) {
+        pagmo_throw(std::invalid_argument, "The ker size parameter must be >=2  while a value of "
+                                               + std::to_string(ker) + " was detected");
+    }
 }
 
 /// Algorithm evolve method
@@ -153,9 +157,9 @@ population gaco::evolve(population pop) const
                                                + std::to_string(pop.size()) + " detected");
     }
     // I verify that the solution archive is smaller or equal than the population size
-    if (m_ker > pop_size || m_ker < 2) {
+    if (m_ker > pop_size) {
         pagmo_throw(std::invalid_argument,
-                    get_name() + " cannot work with a solution archive bigger than the population size or smaller than 2");
+                    get_name() + " cannot work with a solution archive bigger than the population size");
     }
     if (n_obj != 1u) {
         pagmo_throw(std::invalid_argument, "Multiple objectives detected in " + prob.get_name() + " instance. "

--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -97,7 +97,9 @@ gaco::gaco(unsigned gen, unsigned ker, double q, double oracle, double acc, unsi
  *
  * @param pop population to be evolved
  * @return evolved population
- * @throw std::invalid_argument if pop.get_problem() is stochastic.
+ * @throw std::invalid_argument if pop.get_problem() is multi-objective or stochastic
+ * @throw std::invalid_argument if the population size is not at least 2
+ * @throw std::invalid_argument if kernel parameter is bigger than the population size
  */
 population gaco::evolve(population pop) const
 {

--- a/src/algorithms/gaco.cpp
+++ b/src/algorithms/gaco.cpp
@@ -148,6 +148,10 @@ population gaco::evolve(population pop) const
     if (m_gen == 0u) {
         return pop;
     }
+    if (pop_size < 2u) {
+        pagmo_throw(std::invalid_argument, get_name() + " needs at least 2 individuals in the population, "
+                                               + std::to_string(pop.size()) + " detected");
+    }
     // I verify that the solution archive is smaller or equal than the population size
     if (m_ker > pop_size || m_ker < 2) {
         pagmo_throw(std::invalid_argument,

--- a/tests/gaco.cpp
+++ b/tests/gaco.cpp
@@ -122,6 +122,8 @@ BOOST_AUTO_TEST_CASE(evolve_test)
     BOOST_CHECK_THROW(gaco{2u}.evolve(population{problem{zdt{}}, 64u}), std::invalid_argument);
     // Population size smaller than ker size
     BOOST_CHECK_THROW(gaco{2u}.evolve(population{problem{rosenbrock{}}, 60u}), std::invalid_argument);
+    // Population size smaller than 2
+    BOOST_CHECK_THROW(gaco{1u}.evolve(population{problem{rosenbrock{}}, 1}), std::invalid_argument);
     // Stochastic problem
     BOOST_CHECK_THROW((gaco{}.evolve(population{inventory{}, 65u, 23u})), std::invalid_argument);
     // and a clean exit for 0 generation

--- a/tests/gaco.cpp
+++ b/tests/gaco.cpp
@@ -67,6 +67,7 @@ BOOST_AUTO_TEST_CASE(construction_test)
     BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 3u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
     BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
     BOOST_CHECK_THROW((gaco{2u, 13u, 1.0, 0.0, 0.01, 0u, 7u, 1000u, 1000u, 0.0, true, 23u}), std::invalid_argument);
+    BOOST_CHECK_THROW((gaco{2u, 1u, 1.0, 0.0, 0.01, 1u, 7u, 1000u, 1000u, 0.0, false, 23u}), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(evolve_test)


### PR DESCRIPTION
Bugfix for [issue #490](https://github.com/esa/pagmo2/issues/490): `gaco` should throw if `ker` size is < 2