### PR TITLE
Bump min boost version to 1.68

### DIFF
--- a/cmake_modules/PagmoFindBoost.cmake
+++ b/cmake_modules/PagmoFindBoost.cmake
@@ -1,6 +1,6 @@
 # Run a first pass for finding the headers only,
 # and establishing the Boost version.
-set(_PAGMO_BOOST_MINIMUM_VERSION 1.60.0)
+set(_PAGMO_BOOST_MINIMUM_VERSION 1.68.0)
 find_package(Boost ${_PAGMO_BOOST_MINIMUM_VERSION} QUIET REQUIRED)
 
 set(_PAGMO_REQUIRED_BOOST_LIBS serialization)

--- a/doc/sphinx/install.rst
+++ b/doc/sphinx/install.rst
@@ -17,7 +17,7 @@ The officially-supported architectures are 64-bit x86, ARM and PowerPC.
 
 The pagmo C++ library has the following **mandatory** dependencies:
 
-* the `Boost <https://www.boost.org/>`__ C++ libraries (at least version 1.60),
+* the `Boost <https://www.boost.org/>`__ C++ libraries (at least version 1.68),
 * the `Intel TBB <https://github.com/oneapi-src/oneTBB/>`__ library.
 
 Additionally, pagmo has the following **optional** dependencies:


### PR DESCRIPTION
Since build with boost<1.68 fails with:

```
boost/type_traits/is_virtual_base_of.hpp:63:12: error: cannot derive from ‘final’ base ‘pagmo::detail::isl_inner<pagmo::fork_island>’ in derived type ‘boost::detail::is_virtual_base_of_impl<pagmo::detail::isl_inner_base, pagmo::detail::isl_inner<pagmo::fork_island>, boost::integral_constant<bool, true> >::boost_type_traits_internal_struct_X’
```