### PR TITLE
Fix for perturbation in Monotonic Basin Hopping (Issue #505)

### DIFF
--- a/include/pagmo/algorithms/mbh.hpp
+++ b/include/pagmo/algorithms/mbh.hpp
@@ -281,13 +281,7 @@ private:
 
     algorithm m_algorithm;
     unsigned m_stop;
-    // The member m_perturb is mutable as to allow to construct mbh also using a perturbation defined as a scalar
-    // (in which case upon the first call to evolve it is expanded to the problem dimension)
-    // and as a vector (in which case mbh will only operate on problem having the correct dimension)
-    // While the use of "mutable" is not encouraged, in this case the alternative would be to have the user
-    // construct the mbh algo passing one further parameter (the problem dmension) rather than having this determined
-    // upon the first call to evolve.
-    mutable std::vector<double> m_perturb;
+    std::vector<double> m_perturb;
     mutable detail::random_engine_type m_e;
     unsigned m_seed;
     unsigned m_verbosity;

--- a/src/algorithms/mbh.cpp
+++ b/src/algorithms/mbh.cpp
@@ -129,7 +129,7 @@ population mbh::evolve(population pop) const
     }
     // Check if the perturbation vector has size 1, in which case the whole perturbation vector is filled with
     // the same value equal to its first entry
-    auto perturb = m_perturb;
+    vector_double perturb = m_perturb;
     if (perturb.size() == 1u) {
         for (decltype(dim) i = 1u; i < dim; ++i) {
             perturb.push_back(perturb[0]);

--- a/src/algorithms/mbh.cpp
+++ b/src/algorithms/mbh.cpp
@@ -129,14 +129,15 @@ population mbh::evolve(population pop) const
     }
     // Check if the perturbation vector has size 1, in which case the whole perturbation vector is filled with
     // the same value equal to its first entry
-    if (m_perturb.size() == 1u) {
+    auto perturb = m_perturb;
+    if (perturb.size() == 1u) {
         for (decltype(dim) i = 1u; i < dim; ++i) {
-            m_perturb.push_back(m_perturb[0]);
+            perturb.push_back(perturb[0]);
         }
     }
     // Check that the perturbation vector size equals the size of the problem
-    if (m_perturb.size() != dim) {
-        pagmo_throw(std::invalid_argument, "The perturbation vector size is: " + std::to_string(m_perturb.size())
+    if (perturb.size() != dim) {
+        pagmo_throw(std::invalid_argument, "The perturbation vector size is: " + std::to_string(perturb.size())
                                                + ", while the problem dimension is: " + std::to_string(dim)
                                                + ". They need to be equal for MBH to work.");
     }
@@ -154,8 +155,8 @@ population mbh::evolve(population pop) const
             vector_double tmp_x(dim);
             for (decltype(dim) k = 0u; k < dim; ++k) {
                 tmp_x[k]
-                    = uniform_real_from_range(std::max(pop.get_x()[j][k] - m_perturb[k] * (ub[k] - lb[k]), lb[k]),
-                                              std::min(pop.get_x()[j][k] + m_perturb[k] * (ub[k] - lb[k]), ub[k]), m_e);
+                    = uniform_real_from_range(std::max(pop.get_x()[j][k] - perturb[k] * (ub[k] - lb[k]), lb[k]),
+                                              std::min(pop.get_x()[j][k] + perturb[k] * (ub[k] - lb[k]), ub[k]), m_e);
             }
             pop.set_x(j, tmp_x); // fitness is evaluated here
         }

--- a/tests/mbh.cpp
+++ b/tests/mbh.cpp
@@ -118,6 +118,22 @@ BOOST_AUTO_TEST_CASE(mbh_evolve_test)
         mbh user_algo{compass_search{100u, 0.1, 0.001, 0.7}, 5u, {1e-3, 1e-2}, 23u};
         BOOST_CHECK_THROW(user_algo.evolve(population{problem{hock_schittkowsky_71{}}, 15u}), std::invalid_argument);
     }
+    // Here we test that the algo can be called twice with problems of different dimensions (Issue #505)
+    {
+        // prepare problems and populations
+        problem prob1{rosenbrock{5u}};
+        population pop1{prob1, 5u, 23u};
+
+        problem prob2{rosenbrock{10u}};
+        population pop2{prob2, 5u, 23u};
+
+        // prepare algo with perturbation 0.1
+        mbh user_algo{compass_search{100u, 0.1, 0.001, 0.7}, 5u, 0.1};
+
+        // test
+        user_algo.evolve(pop1);
+        user_algo.evolve(pop2);
+    }
     // And a clean exit for 0 generations
     problem prob{hock_schittkowsky_71{}};
     population pop{prob, 10u};


### PR DESCRIPTION
Creating a function-local copy of the perturbation vector in Monotonic Basin Hopping instead of marking m_perturb as volatile.