### PR TITLE
Fix -Wattributes warning

### DIFF
--- a/include/pagmo/archipelago.hpp
+++ b/include/pagmo/archipelago.hpp
@@ -140,7 +140,7 @@ PAGMO_DLL_PUBLIC std::ostream &operator<<(std::ostream &, migrant_handling);
 class PAGMO_DLL_PUBLIC archipelago
 {
     // Make friends with island.
-    friend class PAGMO_DLL_PUBLIC island;
+    friend class island;
 
     using container_t = std::vector<std::unique_ptr<island>>;
     using size_type_implementation = container_t::size_type;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ function(ADD_PAGMO_TESTCASE arg1)
     target_compile_features(${arg1} PRIVATE cxx_std_17)
     set_property(TARGET ${arg1} PROPERTY CXX_EXTENSIONS NO)
     target_compile_definitions(${arg1} PRIVATE BOOST_ALLOW_DEPRECATED_HEADERS)
-    add_test(${arg1} ${arg1})
+    add_test(NAME ${arg1} COMMAND ${arg1})
 endfunction()
 
 # Tests requiring no dependencies (in alphabetical order)

--- a/tools/gha_windows-2019.ps1
+++ b/tools/gha_windows-2019.ps1
@@ -22,4 +22,4 @@ cmake `
     ..
 
 cmake --build . --config Release --target install
-ctest -VV --output-on-failure -j4
+ctest -VV --output-on-failure -j4 -C Release


### PR DESCRIPTION
- fix a warning
- use add_test with NAME/COMMAND signautre to fix cross compilation