### PR TITLE
Write generational output

### DIFF
--- a/include/pagmo/algorithms/moead_gen.hpp
+++ b/include/pagmo/algorithms/moead_gen.hpp
@@ -93,7 +93,7 @@ public:
     moead_gen(unsigned gen = 1u, std::string weight_generation = "grid", std::string decomposition = "tchebycheff",
           population::size_type neighbours = 20u, double CR = 1.0, double F = 0.5, double eta_m = 20.,
           double realb = 0.9, unsigned limit = 2u, bool preserve_diversity = true,
-          unsigned seed = pagmo::random_device::next());
+          unsigned seed = pagmo::random_device::next(), std::string outfile = "");
 
     // Algorithm evolve method
     population evolve(population) const;
@@ -213,6 +213,7 @@ private:
     bool m_preserve_diversity;
     mutable detail::random_engine_type m_e;
     unsigned m_seed;
+    std::string m_outfile;
     unsigned m_verbosity;
     mutable log_type m_log;
     boost::optional<bfe> m_bfe;

--- a/src/algorithms/moead_gen.cpp
+++ b/src/algorithms/moead_gen.cpp
@@ -404,6 +404,7 @@ std::string moead_gen::get_extra_info() const
     stream(ss, "\n\tDistribution index: ", m_eta_m);
     stream(ss, "\n\tChance for diversity preservation: ", m_realb);
     stream(ss, "\n\tSeed: ", m_seed);
+    stream(ss, "\n\tOutfile: ", m_outfile);
     stream(ss, "\n\tVerbosity: ", m_verbosity);
     return ss.str();
 }

--- a/src/algorithms/moead_gen.cpp
+++ b/src/algorithms/moead_gen.cpp
@@ -51,14 +51,17 @@ see https://www.gnu.org/licenses/. */
 // the other serialization headers.
 #include <boost/serialization/optional.hpp>
 
+
+#include <cstdio>
+
 namespace pagmo
 {
 
 moead_gen::moead_gen(unsigned gen, std::string weight_generation, std::string decomposition, population::size_type neighbours,
-             double CR, double F, double eta_m, double realb, unsigned limit, bool preserve_diversity, unsigned seed)
+             double CR, double F, double eta_m, double realb, unsigned limit, bool preserve_diversity, unsigned seed, std::string outfile)
     : m_gen(gen), m_weight_generation(weight_generation), m_decomposition(decomposition), m_neighbours(neighbours),
       m_CR(CR), m_F(F), m_eta_m(eta_m), m_realb(realb), m_limit(limit), m_preserve_diversity(preserve_diversity),
-      m_e(seed), m_seed(seed), m_verbosity(0u)
+      m_e(seed), m_seed(seed), m_outfile(outfile), m_verbosity(0u)
 {
     // Sanity checks
     if (m_weight_generation != "random" && m_weight_generation != "grid" && m_weight_generation != "low discrepancy") {
@@ -175,8 +178,26 @@ population moead_gen::evolve(population pop) const
 
     // Main Generational MOEA/D loop --------------------------------------------------------------------------------------------
     for (decltype(m_gen) gen = 1u; gen <= m_gen; ++gen) {
+        // 0a - custom logging of entire population at each gen
+        if (m_outfile != ""){
+            FILE *ostrm;
+            ostrm = fopen(m_outfile.c_str(), "w");
+                for (decltype(pop.size()) i = 0u; i < pop.size(); ++i) {
+                    vector_double pop_gen_x = pop.get_x()[i];
+                    for (decltype(pop_gen_x.size()) j = 0u; j < pop_gen_x.size(); ++j) {
+                        fprintf(ostrm, "%f, ", pop_gen_x[j]);
+                    }
+                    vector_double pop_gen_f = pop.get_f()[i];
+                    for (decltype(pop_gen_f.size()) j = 0u; j < pop_gen_f.size(); ++j) {
+                        if(j < pop.get_f()[i].size()-1)
+                            fprintf(ostrm, "%f, ", pop_gen_f[j]);
+                        else
+                            fprintf(ostrm, "%f\n", pop_gen_f[j]);
+                    }
+                }
+            fclose(ostrm);
+        }
         // 0 - Logs and prints (verbosity modes > 1: a line is added every m_verbosity generations)
-
         if (m_verbosity > 0u) {
             // Every m_verbosity generations print a log line
             if (gen % m_verbosity == 1u || m_verbosity == 1u) {
@@ -392,7 +413,7 @@ template <typename Archive>
 void moead_gen::serialize(Archive &ar, unsigned)
 {
     detail::archive(ar, m_gen, m_weight_generation, m_decomposition, m_neighbours, m_CR, m_F, m_eta_m, m_realb, m_limit,
-                    m_preserve_diversity, m_e, m_seed, m_verbosity, m_log, m_bfe);
+                    m_preserve_diversity, m_e, m_seed, m_outfile, m_verbosity, m_log, m_bfe);
 }
 
 std::vector<population::size_type>

--- a/src/algorithms/moead_gen.cpp
+++ b/src/algorithms/moead_gen.cpp
@@ -181,7 +181,7 @@ population moead_gen::evolve(population pop) const
         // 0a - custom logging of entire population at each gen
         if (m_outfile != ""){
             FILE *ostrm;
-            ostrm = fopen(m_outfile.c_str(), "w");
+            ostrm = fopen(m_outfile.c_str(), "a");
                 for (decltype(pop.size()) i = 0u; i < pop.size(); ++i) {
                     vector_double pop_gen_x = pop.get_x()[i];
                     for (decltype(pop_gen_x.size()) j = 0u; j < pop_gen_x.size(); ++j) {


### PR DESCRIPTION
So I have a particular problem where I would like to save *ALL* the outputs from the evolutionary algorithm I'm using, not just the final population. I have hardcoded a method for implementing this, where I simply save the population at each generation to a csv file. 

Adding this PR here mainly to ask if this would be a worthwhile implementation to add across the board (either as an additional parameter, or as an additional public function similar to `set_verbosity()`.

As is, I would not pull this in but was wondering if it was worth developing further.