### PR TITLE
CMake: Find Boost using CONFIG mode only

### DIFF
--- a/cmake_modules/PagmoFindBoost.cmake
+++ b/cmake_modules/PagmoFindBoost.cmake
@@ -1,7 +1,7 @@
 # Run a first pass for finding the headers only,
 # and establishing the Boost version.
 set(_PAGMO_BOOST_MINIMUM_VERSION 1.68.0)
-find_package(Boost ${_PAGMO_BOOST_MINIMUM_VERSION} QUIET REQUIRED)
+find_package(Boost ${_PAGMO_BOOST_MINIMUM_VERSION} QUIET REQUIRED CONFIG)
 
 set(_PAGMO_REQUIRED_BOOST_LIBS serialization)
 
@@ -11,7 +11,7 @@ if(_PAGMO_FIND_BOOST_UNIT_TEST_FRAMEWORK)
 endif()
 
 message(STATUS "Required Boost libraries: ${_PAGMO_REQUIRED_BOOST_LIBS}")
-find_package(Boost ${_PAGMO_BOOST_MINIMUM_VERSION} REQUIRED COMPONENTS ${_PAGMO_REQUIRED_BOOST_LIBS})
+find_package(Boost ${_PAGMO_BOOST_MINIMUM_VERSION} REQUIRED CONFIG COMPONENTS ${_PAGMO_REQUIRED_BOOST_LIBS})
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Not all requested Boost components were found, exiting.")
 endif()

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -1363,15 +1363,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -2031,14 +2022,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'pagmo'
-copyright = '2017-2021, pagmo development team'
+copyright = '2017-2024, pagmo development team'
 author = 'pagmo development team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -382,3 +382,6 @@ texinfo_documents = [
 #     app.add_stylesheet("pagmo.css")  # also can be a full URL
 
 linkcheck_workers = 1
+
+# those can fail on remote CI
+linkcheck_ignore = [r'https://www.sciencedirect.com/*', r'https://ieeexplore.ieee.org/*']

--- a/src/batch_evaluators/default_bfe.cpp
+++ b/src/batch_evaluators/default_bfe.cpp
@@ -69,7 +69,9 @@ vector_double default_bfe_cpp_impl(const problem &p, const vector_double &dvs)
 
 } // namespace
 
+/// @cond
 std::function<vector_double(const problem &, const vector_double &)> default_bfe_impl = &default_bfe_cpp_impl;
+/// @endcond
 
 } // namespace detail
 

--- a/src/detail/gte_getter.cpp
+++ b/src/detail/gte_getter.cpp
@@ -48,7 +48,9 @@ boost::any default_gte_getter()
 
 } // namespace
 
+/// @cond
 std::function<boost::any()> gte_getter = &default_gte_getter;
+/// @endcond
 
 } // namespace detail
 

--- a/src/island.cpp
+++ b/src/island.cpp
@@ -159,7 +159,9 @@ boost::any default_wait_raii_getter()
 
 // NOTE: the default implementation just returns a defected boost::any, whose ctor and dtor
 // will have no effect.
+/// @cond
 std::function<boost::any()> wait_raii_getter = &default_wait_raii_getter;
+/// @endcond
 
 namespace
 {
@@ -184,8 +186,10 @@ void default_island_factory(const algorithm &algo, const population &pop, std::u
 } // namespace
 
 // Static init.
+/// @cond
 std::function<void(const algorithm &, const population &, std::unique_ptr<detail::isl_inner_base> &)> island_factory
     = &default_island_factory;
+/// @endcond
 
 namespace
 {


### PR DESCRIPTION
the module mode is deprecated in cmake>=3.30:
```
CMake Warning (dev) at cmake_modules/PagmoFindBoost.cmake:4 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

Call Stack (most recent call first):
  CMakeLists.txt:186 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```