### PR TITLE
Add missing Ipopt return codes.

### DIFF
--- a/src/algorithms/ipopt.cpp
+++ b/src/algorithms/ipopt.cpp
@@ -101,6 +101,8 @@ const ipopt_result_map_t ipopt_results = {PAGMO_DETAIL_IPOPT_RES_ENTRY(Solve_Suc
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Maximum_Iterations_Exceeded),
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Restoration_Failed),
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Error_In_Step_Computation),
+                                          PAGMO_DETAIL_IPOPT_RES_ENTRY(Maximum_CpuTime_Exceeded),
+                                          PAGMO_DETAIL_IPOPT_RES_ENTRY(Maximum_WallTime_Exceeded),
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Not_Enough_Degrees_Of_Freedom),
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Invalid_Problem_Definition),
                                           PAGMO_DETAIL_IPOPT_RES_ENTRY(Invalid_Option),


### PR DESCRIPTION
Maximum_CpuTime_Exceeded return code was introduced in at least Ipopt 3.10.4 (2013-05-05). Maximum_WallTime_Exceeded return code was added in Ipopt 3.14.0 (2021-06-15). Please, see Ipopt changelog for details: https://coin-or.github.io/Ipopt/md_ChangeLog.html. Add missing Ipopt return codes.

Without these return codes, the pagmo2 throws an exception when any of these conditions is satisfied.