### PR TITLE
Drop ciso646 deprecated header

### DIFF
--- a/config.hpp.in
+++ b/config.hpp.in
@@ -31,7 +31,7 @@ see https://www.gnu.org/licenses/. */
 
 // NOTE: include this so that we can
 // detect _LIBCPP_VERSION below.
-#include <ciso646>
+#include <vector>
 
 // Start of defines instantiated by CMake.
 // clang-format off

--- a/include/pagmo/algorithms/ipopt.hpp
+++ b/include/pagmo/algorithms/ipopt.hpp
@@ -94,12 +94,12 @@ PAGMO_DLL_PUBLIC unsigned ipopt_internal_test();
  * - *numeric* options (i.e., the type of the option is ``double``).
  *
  * The full list of options is available on the
- * <a href="https://www.coin-or.org/Ipopt/documentation/node40.html">Ipopt website</a>. pagmo::ipopt allows to configure
+ * <a href="https://coin-or.github.io/Ipopt/OPTIONS.html">Ipopt website</a>. pagmo::ipopt allows to configure
  * any Ipopt option via methods such as ipopt::set_string_options(), ipopt::set_string_option(),
  * ipopt::set_integer_options(), etc., which need to be used before invoking ipopt::evolve().
  *
  * If the user does not set any option, pagmo::ipopt will use Ipopt's default values for the options (see the
- * <a href="https://www.coin-or.org/Ipopt/documentation/node40.html">documentation</a>), with the following
+ * <a href="https://coin-or.github.io/Ipopt/OPTIONS.html">documentation</a>), with the following
  * modifications:
  * - if the ``"print_level"`` integer option is **not** set by the user, it will be set to 0 by pagmo::ipopt (this will
  *   suppress most screen output produced by the solver - note that we support an alternative form of logging via

--- a/tools/gha_deploydocs.sh
+++ b/tools/gha_deploydocs.sh
@@ -10,14 +10,11 @@ set -e
 sudo apt-get install wget
 
 # Install conda+deps.
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh
 export deps_dir=$HOME/local
-export PATH="$HOME/miniconda/bin:$PATH"
-bash miniconda.sh -b -p $HOME/miniconda
-conda config --add channels conda-forge
-conda config --set channel_priority strict
-conda install mamba
-mamba create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 sphinx=4.5.0 sphinx-book-theme breathe doxygen graphviz
+export PATH="$HOME/miniforge/bin:$PATH"
+bash miniforge.sh -b -p $HOME/miniforge
+conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 sphinx=4.5.0 sphinx-book-theme breathe doxygen graphviz
 source activate $deps_dir
 
 ## Create the build dir and cd into it.

--- a/tools/gha_deploydocs.sh
+++ b/tools/gha_deploydocs.sh
@@ -14,7 +14,7 @@ wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge
 export deps_dir=$HOME/local
 export PATH="$HOME/miniforge/bin:$PATH"
 bash miniforge.sh -b -p $HOME/miniforge
-conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 sphinx=4.5.0 sphinx-book-theme breathe doxygen graphviz
+conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 sphinx=4.5.0 sphinx-book-theme breathe "doxygen<1.13" graphviz
 source activate $deps_dir
 
 ## Create the build dir and cd into it.


### PR DESCRIPTION
Else I get a warning with gcc 15:
```
/usr/include/c++/15/ciso646:46:4: warning: #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Wcpp]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
```

I checked including vector instead also yields the _LIBCPP_VERSION macro with clang/libc++

Also fixes the doc CI job