### PR TITLE
Possible 50% performance improvement for NSGA-II on MSVC 

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/include/pagmo/utils/multi_objective.hpp
+++ b/include/pagmo/utils/multi_objective.hpp
@@ -83,6 +83,9 @@ PAGMO_DLL_PUBLIC std::vector<pop_size_t> sort_population_mo(const std::vector<ve
 // Selects the best N individuals in multi-objective optimization
 PAGMO_DLL_PUBLIC std::vector<pop_size_t> select_best_N_mo(const std::vector<vector_double> &, pop_size_t);
 
+// Selects the best N individuals in multi-objective optimization with pre-allocated buffers
+PAGMO_DLL_PUBLIC std::vector<pop_size_t> select_best_N_mo_buffered(const std::vector<vector_double> &, pop_size_t, fnds_return_type&);
+
 // Ideal point
 PAGMO_DLL_PUBLIC vector_double ideal(const std::vector<vector_double> &);
 

--- a/include/pagmo/utils/multi_objective.hpp
+++ b/include/pagmo/utils/multi_objective.hpp
@@ -59,7 +59,7 @@ PAGMO_DLL_PUBLIC void reksum(std::vector<std::vector<double>> &, const std::vect
 } // namespace detail
 
 // Pareto-dominance
-PAGMO_DLL_PUBLIC bool pareto_dominance(const vector_double &, const vector_double &);
+PAGMO_DLL_PUBLIC inline bool pareto_dominance(const vector_double &, const vector_double &);
 
 // Non dominated front 2D (Kung's algorithm)
 PAGMO_DLL_PUBLIC std::vector<pop_size_t> non_dominated_front_2d(const std::vector<vector_double> &);
@@ -70,6 +70,9 @@ using fnds_return_type = std::tuple<std::vector<std::vector<pop_size_t>>, std::v
 
 // Fast non dominated sorting
 PAGMO_DLL_PUBLIC fnds_return_type fast_non_dominated_sorting(const std::vector<vector_double> &);
+
+// Fast non dominated sorting with pre-allocated buffers
+PAGMO_DLL_PUBLIC void fast_non_dominated_sorting_buffered(const std::vector<vector_double> &, fnds_return_type&);
 
 // Crowding distance
 PAGMO_DLL_PUBLIC vector_double crowding_distance(const std::vector<vector_double> &);

--- a/src/algorithms/nsga2.cpp
+++ b/src/algorithms/nsga2.cpp
@@ -135,6 +135,7 @@ population nsga2::evolve(population pop) const
     std::vector<vector_double::size_type> best_idx(NP), shuffle1(NP), shuffle2(NP);
     vector_double::size_type parent1_idx, parent2_idx;
     std::pair<vector_double, vector_double> children;
+    vector_double pop_cd(NP);   // crowding distances of the whole population
 
     // We're using select_best_N_mo_buffered(), which prevents re-allocation of this structure
     fnds_return_type best_N_buffer{};
@@ -187,7 +188,8 @@ population nsga2::evolve(population pop) const
         // 1 - We compute crowding distance and non dominated rank for the current population
         fast_non_dominated_sorting_buffered(pop.get_f(), fnds_buffer);
         auto& ndf = std::get<0>(fnds_buffer); // non dominated fronts [[0,3,2],[1,5,6],[4],...]
-        vector_double pop_cd(NP);         // crowding distances of the whole population
+        // Reset the pop_cd to being empty - that is, set all values to zero
+        std::fill(pop_cd.begin(), pop_cd.end(), 0);
         auto& ndr = std::get<3>(fnds_buffer); // non domination rank [0,1,0,0,2,1,1, ... ]
         for (const auto &front_idxs : ndf) {
             if (front_idxs.size() == 1u) { // handles the case where the front has collapsed to one point

--- a/src/algorithms/nsga2.cpp
+++ b/src/algorithms/nsga2.cpp
@@ -135,9 +135,8 @@ population nsga2::evolve(population pop) const
     std::vector<vector_double::size_type> best_idx(NP), shuffle1(NP), shuffle2(NP);
     vector_double::size_type parent1_idx, parent2_idx;
     std::pair<vector_double, vector_double> children;
-    vector_double pop_cd(NP); // Crowding distances of the whole population
-    std::vector<vector_double> front_cd; // For the crowding distance loop
-    population popnew(pop); // Used to contain a copy of the old population
+    vector_double pop_cd(NP); // crowding distances of the whole population
+    std::vector<vector_double> front_cd; // for the crowding distance loop
 
     // We're using select_best_N_mo_buffered(), which prevents re-allocation of this structure
     fnds_return_type best_N_buffer{};
@@ -181,7 +180,7 @@ population nsga2::evolve(population pop) const
         }
 
         // At each generation we make a copy of the population into popnew
-        popnew = pop;
+        population popnew(pop);
 
         // We create some pseudo-random permutation of the population indexes
         std::shuffle(shuffle1.begin(), shuffle1.end(), m_e);

--- a/src/algorithms/nsga2.cpp
+++ b/src/algorithms/nsga2.cpp
@@ -135,7 +135,8 @@ population nsga2::evolve(population pop) const
     std::vector<vector_double::size_type> best_idx(NP), shuffle1(NP), shuffle2(NP);
     vector_double::size_type parent1_idx, parent2_idx;
     std::pair<vector_double, vector_double> children;
-    vector_double pop_cd(NP);   // crowding distances of the whole population
+    vector_double pop_cd(NP); // crowding distances of the whole population
+    std::vector<vector_double> front_cd; // for the crowding distance loop
 
     // We're using select_best_N_mo_buffered(), which prevents re-allocation of this structure
     fnds_return_type best_N_buffer{};
@@ -188,9 +189,11 @@ population nsga2::evolve(population pop) const
         // 1 - We compute crowding distance and non dominated rank for the current population
         fast_non_dominated_sorting_buffered(pop.get_f(), fnds_buffer);
         auto& ndf = std::get<0>(fnds_buffer); // non dominated fronts [[0,3,2],[1,5,6],[4],...]
-        // Reset the pop_cd to being empty - that is, set all values to zero
-        std::fill(pop_cd.begin(), pop_cd.end(), 0);
         auto& ndr = std::get<3>(fnds_buffer); // non domination rank [0,1,0,0,2,1,1, ... ]
+
+        // Reset the pop_cd to being empty - that is, set all values to zero
+        std::fill(pop_cd.begin(), pop_cd.end(), 0.0);
+
         for (const auto &front_idxs : ndf) {
             if (front_idxs.size() == 1u) { // handles the case where the front has collapsed to one point
                 pop_cd[front_idxs[0]] = std::numeric_limits<double>::infinity();
@@ -199,11 +202,11 @@ population nsga2::evolve(population pop) const
                     pop_cd[front_idxs[0]] = std::numeric_limits<double>::infinity();
                     pop_cd[front_idxs[1]] = std::numeric_limits<double>::infinity();
                 } else {
-                    std::vector<vector_double> front;
-                    for (auto idx : front_idxs) {
-                        front.push_back(pop.get_f()[idx]);
+                    front_cd.clear();
+                    for (const auto idx : front_idxs) {
+                        front_cd.push_back(pop.get_f()[idx]);
                     }
-                    auto cd = crowding_distance(front);
+                    const auto cd = crowding_distance(front_cd);
                     for (decltype(cd.size()) i = 0u; i < cd.size(); ++i) {
                         pop_cd[front_idxs[i]] = cd[i];
                     }

--- a/src/algorithms/nsga2.cpp
+++ b/src/algorithms/nsga2.cpp
@@ -135,7 +135,6 @@ population nsga2::evolve(population pop) const
     std::vector<vector_double::size_type> best_idx(NP), shuffle1(NP), shuffle2(NP);
     vector_double::size_type parent1_idx, parent2_idx;
     std::pair<vector_double, vector_double> children;
-    vector_double pop_cd(NP);   // crowding distances of the whole population
 
     // We're using select_best_N_mo_buffered(), which prevents re-allocation of this structure
     fnds_return_type best_N_buffer{};
@@ -188,8 +187,7 @@ population nsga2::evolve(population pop) const
         // 1 - We compute crowding distance and non dominated rank for the current population
         fast_non_dominated_sorting_buffered(pop.get_f(), fnds_buffer);
         auto& ndf = std::get<0>(fnds_buffer); // non dominated fronts [[0,3,2],[1,5,6],[4],...]
-        // Reset the pop_cd to being empty - that is, set all values to zero
-        std::fill(pop_cd.begin(), pop_cd.end(), 0);
+        vector_double pop_cd(NP);         // crowding distances of the whole population
         auto& ndr = std::get<3>(fnds_buffer); // non domination rank [0,1,0,0,2,1,1, ... ]
         for (const auto &front_idxs : ndf) {
             if (front_idxs.size() == 1u) { // handles the case where the front has collapsed to one point

--- a/src/algorithms/nsga2.cpp
+++ b/src/algorithms/nsga2.cpp
@@ -135,8 +135,9 @@ population nsga2::evolve(population pop) const
     std::vector<vector_double::size_type> best_idx(NP), shuffle1(NP), shuffle2(NP);
     vector_double::size_type parent1_idx, parent2_idx;
     std::pair<vector_double, vector_double> children;
-    vector_double pop_cd(NP); // crowding distances of the whole population
-    std::vector<vector_double> front_cd; // for the crowding distance loop
+    vector_double pop_cd(NP); // Crowding distances of the whole population
+    std::vector<vector_double> front_cd; // For the crowding distance loop
+    population popnew(pop); // Used to contain a copy of the old population
 
     // We're using select_best_N_mo_buffered(), which prevents re-allocation of this structure
     fnds_return_type best_N_buffer{};
@@ -180,7 +181,7 @@ population nsga2::evolve(population pop) const
         }
 
         // At each generation we make a copy of the population into popnew
-        population popnew(pop);
+        popnew = pop;
 
         // We create some pseudo-random permutation of the population indexes
         std::shuffle(shuffle1.begin(), shuffle1.end(), m_e);


### PR DESCRIPTION
Hello everyone,
as part of my Master's Thesis (Faculty of Applied Sciences, University of West Bohemia), I have been investigating the poor performance of pagmo2's implementation of NSGA2 when compiled with MSVC. The changes that I've made decrease the execution time by about 50% (MSVC 19.44.35217). This improvement was possible due to the inefficiency of `std::isnan` in the MSVC Runtime Library.
Other compilers such as (Clang and GCC) benefit mainly from the memory optimizations, decreasing the execution time by about 15%. 

The main changes in this PR include:
- Reimplemented` less_than_f`, `greater_than_f`, `equal_to_f` using C++20 starship operator
	- 30% performance improvement on MSVC
- Inlined `pareto_dominance()`
	- Eliminated high function call overhead in hot path loops
- Added `fast_non_dominated_sorting_buffered()` and `select_best_N_mo_buffered()`
	- Prevents repeated destruction an re-allocation of std::vectors that are used as a return value
	- Obviously this "duplicates" the logic of these functions, however making a new function which has the pre-allocated struct passed to it as parameter was the only option since these functions aren't part of any class we can't use class members for this 

Detailed explanation together with the code that was used for profiling can be found here: https://github.com/jonas-s-s-s/Pagmo-NSGA2-Improve-Test