### PR TITLE
fix: resolve clang >= 17 compilation error in extract<const T>()

### DIFF
--- a/include/pagmo/algorithm.hpp
+++ b/include/pagmo/algorithm.hpp
@@ -366,7 +366,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -529,8 +529,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::algo_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::algo_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
 
@@ -566,8 +566,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::algo_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::algo_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
 

--- a/include/pagmo/bfe.hpp
+++ b/include/pagmo/bfe.hpp
@@ -222,7 +222,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -296,8 +296,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::bfe_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::bfe_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
     template <typename T>
@@ -306,8 +306,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::bfe_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::bfe_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
     template <typename T>

--- a/include/pagmo/detail/typeid_name_extract.hpp
+++ b/include/pagmo/detail/typeid_name_extract.hpp
@@ -54,18 +54,12 @@ namespace detail
 template <typename T, typename C>
 inline typename std::conditional<std::is_const<C>::value, const T *, T *>::type typeid_name_extract(C &class_inst)
 {
-    // NOTE: typeid() strips away both reference and cv qualifiers. Thus,
-    // if T is cv-qualified or a reference type, return nullptr preemptively
-    // (in any case, extraction cannot be successful in such cases).
-    if (!std::is_same<T, uncvref_t<T>>::value || std::is_reference<T>::value) {
+    if (std::is_reference<T>::value) {
         return nullptr;
     }
-
-    if (std::strcmp(class_inst.get_type_index().name(), typeid(T).name())) {
-        // The names differ, return null.
+    if (std::strcmp(class_inst.get_type_index().name(), typeid(uncvref_t<T>).name())) {
         return nullptr;
     } else {
-        // The names match, cast to the correct type and return.
         return static_cast<typename std::conditional<std::is_const<C>::value, const T *, T *>::type>(
             class_inst.get_ptr());
     }

--- a/include/pagmo/island.hpp
+++ b/include/pagmo/island.hpp
@@ -236,7 +236,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -1021,8 +1021,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto isl = dynamic_cast<const detail::isl_inner<T> *>(m_ptr->isl_ptr.get());
-        return isl == nullptr ? nullptr : &(isl->m_value);
+        auto isl = dynamic_cast<const detail::isl_inner<uncvref_t<T>> *>(m_ptr->isl_ptr.get());
+        return isl == nullptr ? nullptr : reinterpret_cast<const T *>(&(isl->m_value));
 #endif
     }
     /// Extract a pointer to the UDI used for construction.
@@ -1054,8 +1054,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto isl = dynamic_cast<detail::isl_inner<T> *>(m_ptr->isl_ptr.get());
-        return isl == nullptr ? nullptr : &(isl->m_value);
+        auto isl = dynamic_cast<detail::isl_inner<uncvref_t<T>> *>(m_ptr->isl_ptr.get());
+        return isl == nullptr ? nullptr : reinterpret_cast<T *>(&(isl->m_value));
 #endif
     }
     /// Check if the UDI used for construction is of type \p T.

--- a/include/pagmo/problem.hpp
+++ b/include/pagmo/problem.hpp
@@ -874,7 +874,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -1107,8 +1107,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::prob_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::prob_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
 
@@ -1141,8 +1141,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::prob_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::prob_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
 

--- a/include/pagmo/r_policy.hpp
+++ b/include/pagmo/r_policy.hpp
@@ -214,7 +214,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -270,8 +270,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::r_pol_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::r_pol_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
     template <typename T>
@@ -280,8 +280,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::r_pol_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::r_pol_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
     template <typename T>

--- a/include/pagmo/s_policy.hpp
+++ b/include/pagmo/s_policy.hpp
@@ -214,7 +214,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -270,8 +270,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::s_pol_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::s_pol_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
     template <typename T>
@@ -280,8 +280,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::s_pol_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::s_pol_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
     template <typename T>

--- a/include/pagmo/topology.hpp
+++ b/include/pagmo/topology.hpp
@@ -281,7 +281,7 @@ private:
     }
 
 public:
-    T m_value;
+    std::remove_const_t<T> m_value;
 };
 
 } // namespace detail
@@ -340,8 +340,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<const detail::topo_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<const detail::topo_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<const T *>(&(p->m_value));
 #endif
     }
     template <typename T>
@@ -350,8 +350,8 @@ public:
 #if defined(PAGMO_PREFER_TYPEID_NAME_EXTRACT)
         return detail::typeid_name_extract<T>(*this);
 #else
-        auto p = dynamic_cast<detail::topo_inner<T> *>(ptr());
-        return p == nullptr ? nullptr : &(p->m_value);
+        auto p = dynamic_cast<detail::topo_inner<uncvref_t<T>> *>(ptr());
+        return p == nullptr ? nullptr : reinterpret_cast<T *>(&(p->m_value));
 #endif
     }
     template <typename T>

--- a/tests/algorithm.cpp
+++ b/tests/algorithm.cpp
@@ -436,6 +436,13 @@ BOOST_AUTO_TEST_CASE(extract_test)
                               decltype(static_cast<const algorithm &>(p).extract<null_algorithm>())>::value));
     BOOST_CHECK(p.extract<null_algorithm>() != nullptr);
     BOOST_CHECK(static_cast<const algorithm &>(p).extract<null_algorithm>() != nullptr);
+    BOOST_CHECK(p.extract<const null_algorithm>() != nullptr);
+    BOOST_CHECK(static_cast<const algorithm &>(p).extract<const null_algorithm>() != nullptr);
+    BOOST_CHECK(p.is<const null_algorithm>());
+    BOOST_CHECK(static_cast<const algorithm &>(p).is<const null_algorithm>());
+    BOOST_CHECK(p.extract<const null_algorithm>() == static_cast<const null_algorithm *>(p.extract<null_algorithm>()));
+    BOOST_CHECK(static_cast<const algorithm &>(p).extract<const null_algorithm>()
+                == static_cast<const null_algorithm *>(static_cast<const algorithm &>(p).extract<null_algorithm>()));
 }
 
 struct ts1 {

--- a/tests/island.cpp
+++ b/tests/island.cpp
@@ -532,9 +532,7 @@ BOOST_AUTO_TEST_CASE(island_extract)
     BOOST_CHECK((std::is_same<thread_island const *,
                               decltype(static_cast<const island &>(isl).extract<thread_island>())>::value));
     BOOST_CHECK(isl.is<thread_island>());
-#if !defined(_MSC_VER) || defined(__clang__)
-    BOOST_CHECK(isl.extract<const thread_island>() == nullptr);
-#endif
+    BOOST_CHECK(isl.extract<const thread_island>() != nullptr);
     BOOST_CHECK(isl.extract<udi_01>() == nullptr);
     BOOST_CHECK(!isl.is<udi_01>());
     isl = island(udi_01{}, stateful_algo{}, null_problem{}, 20);
@@ -545,9 +543,7 @@ BOOST_AUTO_TEST_CASE(island_extract)
     BOOST_CHECK((std::is_same<udi_01 *, decltype(isl.extract<udi_01>())>::value));
     BOOST_CHECK((std::is_same<udi_01 const *, decltype(static_cast<const island &>(isl).extract<udi_01>())>::value));
     BOOST_CHECK(isl.is<udi_01>());
-#if !defined(_MSC_VER) || defined(__clang__)
-    BOOST_CHECK(isl.extract<const udi_01>() == nullptr);
-#endif
+    BOOST_CHECK(isl.extract<const udi_01>() != nullptr);
 }
 
 // Constructors with bfe arguments.


### PR DESCRIPTION
The non-const get_ptr() in UDx inner classes tries to return &m_value as void*, but when T is const-qualified this drops const without an explicit cast, which clang >= 17 rejects. Use std::remove_const_t<T> for the m_value member so &m_value is always a non-const pointer. This avoids const_cast entirely and applies uniformly across all UDx types (island, problem, algorithm, topology, bfe, s_policy, r_policy).

Closes #584.