### PR TITLE
archipelago: auto-sync topology vertex count in set_topology to preve…

### DIFF
--- a/include/pagmo/topology.hpp
+++ b/include/pagmo/topology.hpp
@@ -118,6 +118,21 @@ using bgl_graph_t
 
 #endif
 
+// Detect the num_vertices() method.
+template <typename T>
+class has_num_vertices
+{
+    template <typename U>
+    using num_vertices_t = decltype(std::declval<const U &>().num_vertices());
+    static const bool implementation_defined = std::is_same<std::size_t, detected_t<num_vertices_t, T>>::value;
+
+public:
+    static const bool value = implementation_defined;
+};
+
+template <typename T>
+const bool has_num_vertices<T>::value;
+
 // Detect the to_bgl() method.
 template <typename T>
 class has_to_bgl
@@ -171,6 +186,7 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS topo_inner_base {
     virtual std::string get_name() const = 0;
     virtual std::string get_extra_info() const = 0;
     virtual std::pair<std::vector<std::size_t>, vector_double> get_connections(std::size_t) const = 0;
+    virtual std::size_t num_vertices() const = 0;
     virtual void push_back() = 0;
     virtual bgl_graph_t to_bgl() const = 0;
     virtual std::type_index get_type_index() const = 0;
@@ -196,19 +212,31 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS topo_inner final : topo_inner_base {
     // Constructors from T (copy and move variants).
     explicit topo_inner(const T &x) : m_value(x) {}
     explicit topo_inner(T &&x) : m_value(std::move(x)) {}
-    // The clone method, used in the copy constructor of topology.
     std::unique_ptr<topo_inner_base> clone() const final
     {
-        return std::make_unique<topo_inner>(m_value);
+        auto ptr = std::make_unique<topo_inner>(m_value);
+        ptr->m_fallback_vertices = m_fallback_vertices;
+        return ptr;
     }
     // The mandatory methods.
     std::pair<std::vector<std::size_t>, vector_double> get_connections(std::size_t n) const final
     {
         return m_value.get_connections(n);
     }
+    std::size_t num_vertices() const final
+    {
+        if constexpr (has_num_vertices<T>::value) {
+            return m_value.num_vertices();
+        } else {
+            return m_fallback_vertices;
+        }
+    }
     void push_back() final
     {
         m_value.push_back();
+        if constexpr (!has_num_vertices<T>::value) {
+            ++m_fallback_vertices;
+        }
     }
     // Optional methods.
     bgl_graph_t to_bgl() const final
@@ -273,15 +301,15 @@ struct PAGMO_DLL_PUBLIC_INLINE_CLASS topo_inner final : topo_inner_base {
 
 private:
     friend class boost::serialization::access;
-    // Serialization
     template <typename Archive>
     void serialize(Archive &ar, unsigned)
     {
-        detail::archive(ar, boost::serialization::base_object<topo_inner_base>(*this), m_value);
+        detail::archive(ar, boost::serialization::base_object<topo_inner_base>(*this), m_value, m_fallback_vertices);
     }
 
 public:
     T m_value;
+    std::size_t m_fallback_vertices = 0;
 };
 
 } // namespace detail
@@ -374,6 +402,9 @@ public:
 
     // Get the connections to a vertex.
     std::pair<std::vector<std::size_t>, vector_double> get_connections(std::size_t) const;
+
+    // Get the number of vertices.
+    std::size_t num_vertices() const;
 
     // Add a vertex.
     void push_back();

--- a/src/archipelago.cpp
+++ b/src/archipelago.cpp
@@ -737,11 +737,14 @@ topology archipelago::get_topology() const
  */
 void archipelago::set_topology(topology topo)
 {
-    // NOTE: make sure we finish any ongoing evolution before setting the topology.
-    // The assignment will trigger the destructor of the UDT, so we need to make
-    // sure there's no interaction with the UDT happening.
     wait_check_ignore();
     m_topology = std::move(topo);
+    if (m_topology.num_vertices() < m_islands.size()) {
+        auto to_add = m_islands.size() - m_topology.num_vertices();
+        for (decltype(to_add) i = 0; i < to_add; ++i) {
+            m_topology.push_back();
+        }
+    }
 }
 
 namespace detail

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -142,6 +142,11 @@ std::pair<std::vector<std::size_t>, vector_double> topology::get_connections(std
     return retval;
 }
 
+std::size_t topology::num_vertices() const
+{
+    return ptr()->num_vertices();
+}
+
 void topology::push_back()
 {
     ptr()->push_back();

--- a/tests/archipelago.cpp
+++ b/tests/archipelago.cpp
@@ -525,6 +525,39 @@ BOOST_AUTO_TEST_CASE(archipelago_topology_setter)
     BOOST_CHECK((archi.get_topology().get_connections(1).first == std::vector<std::size_t>{0, 2, 3}));
     BOOST_CHECK((archi.get_topology().get_connections(2).first == std::vector<std::size_t>{0, 1, 3}));
     BOOST_CHECK((archi.get_topology().get_connections(3).first == std::vector<std::size_t>{0, 1, 2}));
+
+    // Test that set_topology with a fresh topology (no pre-populated vertices)
+    // auto-syncs the vertex count and works correctly with evolve.
+    {
+        archipelago archi2{4u, de{}, rosenbrock{5}, 10u};
+        BOOST_CHECK(archi2.get_topology().is<unconnected>());
+        archi2.set_topology(topology{ring{}});
+        BOOST_CHECK(archi2.get_topology().is<ring>());
+        BOOST_CHECK(archi2.get_topology().num_vertices() == 4u);
+        archi2.evolve(2);
+        BOOST_CHECK_NO_THROW(archi2.wait_check());
+    }
+
+    // Legacy custom topology regression: UDA implements push_back() but not
+    // num_vertices(). set_topology() must not hang.
+    {
+        struct legacy_topo {
+            std::pair<std::vector<std::size_t>, vector_double> get_connections(std::size_t) const
+            {
+                return {{}, {}};
+            }
+            void push_back() { ++count; }
+            int count = 0;
+        };
+        archipelago archi2{3u, de{}, rosenbrock{5}, 10u};
+        topology t{legacy_topo{}};
+        BOOST_CHECK(t.num_vertices() == 0u);
+        archi2.set_topology(std::move(t));
+        BOOST_CHECK(archi2.get_topology().num_vertices() == 3u);
+        BOOST_CHECK(archi2.get_topology().extract<legacy_topo>()->count == 3);
+        BOOST_CHECK_NO_THROW(archi2.evolve(1));
+        BOOST_CHECK_NO_THROW(archi2.wait_check());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(archipelago_island_access)

--- a/tests/topology.cpp
+++ b/tests/topology.cpp
@@ -390,3 +390,20 @@ BOOST_AUTO_TEST_CASE(get_ptr)
     BOOST_CHECK(p0.get_ptr() == p0.extract<udt00a>());
     BOOST_CHECK(static_cast<const topology &>(p0).get_ptr() == static_cast<const topology &>(p0).extract<udt00a>());
 }
+
+BOOST_AUTO_TEST_CASE(topology_legacy_fallback_test)
+{
+    BOOST_CHECK(!has_num_vertices<udt00>::value);
+    topology t{udt00{}};
+    BOOST_CHECK(t.num_vertices() == 0u);
+    t.push_back();
+    BOOST_CHECK(t.num_vertices() == 1u);
+    t.push_back(2);
+    BOOST_CHECK(t.num_vertices() == 3u);
+    BOOST_CHECK(t.extract<udt00>()->n_pushed == 3);
+    auto t2 = t;
+    BOOST_CHECK(t2.num_vertices() == 3u);
+    t2.push_back();
+    BOOST_CHECK(t2.num_vertices() == 4u);
+    BOOST_CHECK(t.num_vertices() == 3u);
+}


### PR DESCRIPTION
…nt crash

Calling set_topology() with a freshly constructed topology (e.g. pagmo::topology(pagmo::ring())) would replace the archipelago's topology with one having 0 vertices, while the archipelago may already contain islands. Subsequent evolve() would then crash when get_connections() is called with an out-of-bounds vertex index.

Fix by adding a num_vertices() method to the topology class and modifying set_topology() to automatically call push_back() until the topology has enough vertices for all existing islands.

Fixes #606