### PR TITLE
Fix BFE test for C++20 stateless lambdas

### DIFF
--- a/doc/sphinx/docs/cpp/bfe.rst
+++ b/doc/sphinx/docs/cpp/bfe.rst
@@ -46,8 +46,10 @@ Batch fitness evaluator
    stored contiguously).
 
    Additionally, UDBFEs must also be destructible and default, copy and move constructible.
-   Note that pointers to plain C++ functions with an appropriate signature
-   are UDBFEs, but lambda functions are not (as they currently are not default-constructible).
+   Note that pointers to plain C++ functions with an appropriate signature are UDBFEs.
+   Stateless lambdas are also UDBFEs when their closure types are default-constructible
+   (e.g., when using C++20 or later), while capturing lambdas are not default-constructible
+   and thus are not UDBFEs.
 
    UDBFEs can also implement the following (optional) member functions:
 

--- a/tests/bfe.cpp
+++ b/tests/bfe.cpp
@@ -455,12 +455,30 @@ BOOST_AUTO_TEST_CASE(s11n)
     BOOST_CHECK(bfe0.extract<udbfe_a>()->state = -42);
 }
 
+template <typename T>
+void test_lambda_udbfe(const T &fun)
+{
+    if constexpr (is_udbfe<T>::value) {
+        bfe bfe0{fun};
+        BOOST_CHECK(bfe0.is<T>());
+        bfe bfe1{bfe0};
+        BOOST_CHECK(bfe1.is<T>());
+        BOOST_CHECK(bfe1(problem{}, vector_double{.5}) == vector_double{1.});
+        BOOST_CHECK(bfe1(problem{null_problem{3}}, vector_double{.5}) == (vector_double{1., 1., 1.}));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(lambda_std_function)
 {
     auto fun = [](const problem &p, const vector_double &dvs) {
         return vector_double(p.get_nf() * (dvs.size() / p.get_nx()), 1.);
     };
-    BOOST_CHECK(!is_udbfe<decltype(fun)>::value);
+    BOOST_CHECK(std::is_copy_constructible<decltype(fun)>::value);
+    BOOST_CHECK(std::is_move_constructible<decltype(fun)>::value);
+    BOOST_CHECK(std::is_destructible<decltype(fun)>::value);
+    BOOST_CHECK(has_bfe_call_operator<decltype(fun)>::value);
+    BOOST_CHECK_EQUAL(is_udbfe<decltype(fun)>::value, std::is_default_constructible<decltype(fun)>::value);
+    test_lambda_udbfe(fun);
 #if !defined(_MSC_VER)
     BOOST_CHECK(is_udbfe<decltype(+fun)>::value);
 #endif


### PR DESCRIPTION
Fixes #632

## Summary

C++20 changed the default-constructibility of stateless lambda closure
types. As a result, a stateless lambda that does not satisfy pagmo's
UDBFE requirements under C++17 can satisfy them under C++20.

The existing BFE test assumes unconditionally that the lambda is not a
UDBFE, while `is_udbfe` itself correctly classifies the callable from
its actual type properties.

This change:

- makes the lambda test follow the callable's default-constructibility
  under the selected C++ standard;
- verifies the other UDBFE requirements independently;
- when the lambda is admitted, verifies that it can be stored, copied
  and invoked through `pagmo::bfe`;
- updates the BFE documentation so it no longer states that lambdas are
  categorically non-default-constructible.

No production BFE or type-trait implementation is changed.

## Verification

Using Apple clang 21.0.0 on arm64 macOS:

- C++17 Debug focused BFE test: PASS
- C++17 Debug enabled core suite: 81/81 PASS
- C++20 Debug focused BFE test: PASS
- C++20 Release enabled core suite: 81/81 PASS

A negative-control run restoring the old unconditional
`!is_udbfe<decltype(fun)>` expectation fails under C++20 as expected.

The C++20 Debug full build is blocked independently by an existing
`ATOMIC_VAR_INIT` deprecation promoted to an error by AppleClang 21;
the focused BFE test passes in that configuration.

I did not reproduce the issue's exact GCC 15.3 / GCC 16.1 Linux
environment locally.